### PR TITLE
Enhance setup script to download Go bootstrap

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,14 +3,74 @@
 # Installs dependencies and configures Go bootstrap.
 set -euo pipefail
 
-# Install qemu and build tools if missing.
-if ! command -v qemu-system-x86_64 >/dev/null; then
+# Determine whether we need to install packages required for building Biscuit.
+need_install() {
+  # Check if a package is installed via dpkg.
+  dpkg -s "$1" >/dev/null 2>&1 || return 0
+  return 1
+}
+
+# Required packages for the build.
+packages=(
+  qemu-system-x86   # QEMU emulator for running Biscuit
+  build-essential   # GCC and related build tools
+  python3           # Python required for some build scripts
+  curl              # Preferred tool for downloading Go bootstrap
+  wget              # Fallback download tool
+)
+
+# Bootstrap Go version to download when no system Go is found.
+GO_BOOTSTRAP_VERSION=1.20.7
+
+# Directory where the bootstrap Go will be installed.
+GO_BOOTSTRAP_DIR="$HOME/go-bootstrap"
+
+# Download and unpack the Go bootstrap toolchain into GO_BOOTSTRAP_DIR.
+download_go() {
+  local url="https://dl.google.com/go/go${GO_BOOTSTRAP_VERSION}.linux-amd64.tar.gz"
+  local tarball="/tmp/go${GO_BOOTSTRAP_VERSION}.tar.gz"
+
+  mkdir -p "$GO_BOOTSTRAP_DIR"
+
+  if command -v curl >/dev/null; then
+    # Use curl if available.
+    curl -fsSL "$url" -o "$tarball"
+  elif command -v wget >/dev/null; then
+    # Fallback to wget.
+    wget -qO "$tarball" "$url"
+  else
+    echo "Error: curl or wget is required to download Go" >&2
+    return 1
+  fi
+
+  tar -C "$GO_BOOTSTRAP_DIR" -xzf "$tarball" --strip-components=1
+}
+
+# Gather all packages that are missing.
+missing=()
+for pkg in "${packages[@]}"; do
+  need_install "$pkg" && missing+=("$pkg")
+done
+
+# Install missing packages, if any.
+if [ ${#missing[@]} -ne 0 ]; then
   sudo apt-get update
-  sudo apt-get install -y qemu-system-x86 build-essential python3
+  sudo apt-get install -y "${missing[@]}"
 fi
 
-# Use the system Go for bootstrapping.
-export GOROOT_BOOTSTRAP=$(go env GOROOT)
+# Set up the Go bootstrap toolchain.
+if command -v go >/dev/null; then
+  # If Go exists, use its GOROOT for bootstrapping.
+  export GOROOT_BOOTSTRAP="$(go env GOROOT)"
+else
+  # Otherwise download a lightweight bootstrap toolchain.
+  download_go
+  export GOROOT_BOOTSTRAP="$GO_BOOTSTRAP_DIR"
+fi
 
-# Print Go version for verification.
-go version
+# Print Go version for verification if available.
+if command -v go >/dev/null; then
+  go version
+else
+  "$GOROOT_BOOTSTRAP/bin/go" version
+fi


### PR DESCRIPTION
## Summary
- extend package list and add Go bootstrap download logic in `setup.sh`
- set up a local Go bootstrap if `go` is missing

## Testing
- `bash setup.sh > /tmp/setup.log` *(fails: could not fetch packages)*
- `GO111MODULE=off ./make.bash` within `src`
- `make qemu CPUS=2` *(fails: `make: *** [GNUmakefile:140: ../bin/go] Error 1`)*
- `GO111MODULE=off go test ./...` *(fails: build errors)*
