### PR TITLE
Clarify bootstrap behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,16 @@ of Biscuit's code is in biscuit/.
 
 ## Install
 
-The root of the repository contains the Go 1.10.1 tools/runtime. Some of
-Biscuit's code is modifications to the runtime, mostly in
-src/runtime/os_linux.go.
+The root of the repository contains the Go **1.10.1** tools and runtime.
+Several Biscuit components modify the runtime directly, primarily in
+`src/runtime/os_linux.go`. These changes rely on internal structures from
+Go 1.10 and have not been ported to newer releases. As a result the kernel
+must be built with Go 1.10.1 instead of a modern Go toolchain.
+
+To compile the old runtime using a recent system Go, the `setup.sh` script
+downloads the latest Go release when no local Go installation is found. This
+bootstrap compiler only builds the Biscuit runtime and is not used to build
+kernel code.
 
 Biscuit used to build on Linux and OpenBSD, but probably only builds on Linux
 currently. You must build Biscuit's modified Go runtime before building

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # Setup script for Biscuit build environment.
 # Installs dependencies and configures Go bootstrap.
+#
+# Biscuit uses a forked Go 1.10.1 runtime. When no system Go is
+# available this script downloads a small Go toolchain that is only
+# used for bootstrapping the old runtime. The script fetches the latest
+# stable release of Go so that the toolchain stays up to date.
 set -euo pipefail
 
 # Determine whether we need to install packages required for building Biscuit.
@@ -19,15 +24,26 @@ packages=(
   wget              # Fallback download tool
 )
 
+# Determine the latest stable Go release version number. The go.dev
+# service exposes this via the VERSION?m=text endpoint.
+latest_go_version() {
+  local version_url="https://go.dev/VERSION?m=text"
+  if command -v curl >/dev/null; then
+    curl -fsSL "$version_url"
+  else
+    wget -qO- "$version_url"
+  fi | sed 's/^go//' # Strip the leading "go" prefix.
+}
+
 # Bootstrap Go version to download when no system Go is found.
-GO_BOOTSTRAP_VERSION=1.20.7
+GO_BOOTSTRAP_VERSION="$(latest_go_version)"
 
 # Directory where the bootstrap Go will be installed.
 GO_BOOTSTRAP_DIR="$HOME/go-bootstrap"
 
 # Download and unpack the Go bootstrap toolchain into GO_BOOTSTRAP_DIR.
 download_go() {
-  local url="https://dl.google.com/go/go${GO_BOOTSTRAP_VERSION}.linux-amd64.tar.gz"
+  local url="https://go.dev/dl/go${GO_BOOTSTRAP_VERSION}.linux-amd64.tar.gz"
   local tarball="/tmp/go${GO_BOOTSTRAP_VERSION}.tar.gz"
 
   mkdir -p "$GO_BOOTSTRAP_DIR"
@@ -44,6 +60,7 @@ download_go() {
   fi
 
   tar -C "$GO_BOOTSTRAP_DIR" -xzf "$tarball" --strip-components=1
+  export PATH="$GO_BOOTSTRAP_DIR/bin:$PATH" # Make 'go' command available.
 }
 
 # Gather all packages that are missing.
@@ -60,17 +77,13 @@ fi
 
 # Set up the Go bootstrap toolchain.
 if command -v go >/dev/null; then
-  # If Go exists, use its GOROOT for bootstrapping.
+  # Use existing Go installation for bootstrapping.
   export GOROOT_BOOTSTRAP="$(go env GOROOT)"
 else
-  # Otherwise download a lightweight bootstrap toolchain.
+  # Download a lightweight bootstrap toolchain.
   download_go
   export GOROOT_BOOTSTRAP="$GO_BOOTSTRAP_DIR"
 fi
 
-# Print Go version for verification if available.
-if command -v go >/dev/null; then
-  go version
-else
-  "$GOROOT_BOOTSTRAP/bin/go" version
-fi
+# Show which Go compiler will be used.
+go version


### PR DESCRIPTION
## Summary
- mention latest Go bootstrap in README
- teach `setup.sh` to fetch the latest release automatically and update PATH

## Testing
- `go version`
- `cd src && ./make.bash` *(fails: go cannot find main module)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6839f46166b483318f7ceac54feac8a2