### PR TITLE
Update repo agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,11 @@ All code changes must use modern language paradigms and idiomatic style. Functio
 
 ## Extended Guidelines
 
-- Any file touched must be fully refactored to modern Go **1.22+** idioms (the repository currently uses Go 1.24.x). Decompose complex logic, unroll loops, flatten nested structures, remove outdated patterns, and replace special functions with standard equivalents. Emphasize modern design patterns throughout.
+- Any file touched must be fully refactored to modern Go **1.24.x** idioms. Decompose complex logic, unroll loops, flatten nested structures, remove outdated patterns, and replace special functions with standard equivalents. Emphasize modern design patterns throughout.
 - Apply these refactoring principles recursively to dependent modules and packages so the entire codebase remains consistent.
 - Ensure that all code is thoroughly commented. Each function requires Doxygen-compatible documentation.
 - Always run `gofmt` or an equivalent formatter on changed files after modifications.
 - Before building or testing, install a comprehensive suite of development tools from **apt**, **pip**, and **npm**, including packages from common PPAs and repositories, to provide a maximally provisioned environment.
+- Run `go test -v ./...` to get verbose output. Capture and analyze any failures to understand broader architectural issues and address them holistically.
 
 All modifications must further decompose, unroll, flatten, factor and synthesize the code into modern idiomatic expressions guided by mathematical principles wherever possible.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,15 @@
 
 All code changes must use modern language paradigms and idiomatic style. Functions must be documented using Doxygen-compatible comments detailing purpose, parameters, return values, and global variables. When modifying code, apply formatting and prettification but leave comment-only changes unformatted. Integrate Doxygen with Sphinx using Breathe for documentation builds aimed at Read the Docs. Every modified file must be formatted with `gofmt` and contain Doxygen documentation.
 
+## Repo-wide Priorities
+
+- Always decompose complex logic mathematically, unrolling and flattening structures wherever feasible.
+- Apply philosophical and conceptual analysis when refactoring or synthesizing new code.
+
 ## Extended Guidelines
 
-- Any file touched must be fully refactored to modern Go **1.23.x** idioms. Decompose complex logic, unroll loops, flatten nested structures, remove outdated patterns, and replace special functions with standard equivalents. Emphasize modern design patterns throughout.
+- Any file touched must be fully refactored to modern Go **1.22+** idioms (the repository currently uses Go 1.24.x). Decompose complex logic, unroll loops, flatten nested structures, remove outdated patterns, and replace special functions with standard equivalents. Emphasize modern design patterns throughout.
+- Apply these refactoring principles recursively to dependent modules and packages so the entire codebase remains consistent.
 - Ensure that all code is thoroughly commented. Each function requires Doxygen-compatible documentation.
 - Always run `gofmt` or an equivalent formatter on changed files after modifications.
 - Before building or testing, install a comprehensive suite of development tools from **apt**, **pip**, and **npm**, including packages from common PPAs and repositories, to provide a maximally provisioned environment.


### PR DESCRIPTION
## Summary
- clarify repo-wide decomposition and conceptual refactoring priorities
- specify Go 1.22+ requirement and recursive application of refactoring instructions

## Testing
- `apt-get update`
- `apt-get install -y build-essential`
- `pip install --user wheel`
- `npm install -g typescript`
- `go test ./...` *(fails: setup failed for many packages)*

------
https://chatgpt.com/codex/tasks/task_e_6846a2f776bc8331a5557db81413fb3a

## Summary by Sourcery

Update repository agent instructions to clarify decomposition and conceptual refactoring priorities, set Go version requirement to 1.22+, and enforce recursive refactoring across modules

Documentation:
- Add a "Repo-wide Priorities" section outlining decomposition and conceptual analysis guidelines
- Update Go requirement to 1.22+ (current 1.24.x) in agent guidelines
- Mandate recursive application of refactoring principles to dependent modules and packages