### PR TITLE
Add Doxygen comments to errors package

### DIFF
--- a/src/errors/errors.go
+++ b/src/errors/errors.go
@@ -2,19 +2,27 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package errors implements functions to manipulate errors.
+/// Package errors implements functions to manipulate errors.
 package errors
 
-// New returns an error that formats as the given text.
+/// New returns an error that formats as the given text.
+///
+/// @param text descriptive text for the resulting error
+/// @return error instance wrapping the provided text
 func New(text string) error {
 	return &errorString{text}
 }
 
-// errorString is a trivial implementation of error.
+/// errorString is a trivial implementation of the error interface.
+/// It stores the provided error message as a string.
 type errorString struct {
 	s string
 }
 
+/// Error implements the error interface and returns the underlying
+/// text message.
+///
+/// @return the original error text
 func (e *errorString) Error() string {
 	return e.s
 }


### PR DESCRIPTION
## Summary
- document `errors.New` function
- document `errorString` type and its `Error` method

## Testing
- `gofmt -w src/errors/errors.go`

------
https://chatgpt.com/codex/tasks/task_e_6848f6649a3083319e1b52d9daa123a7