### PR TITLE
Add documentation for exported symbols

### DIFF
--- a/biscuit/src/defs/device.go
+++ b/biscuit/src/defs/device.go
@@ -1,18 +1,20 @@
 package defs
 
+// / Device identifiers used throughout the kernel.
 const (
-	D_CONSOLE int = 1
+	D_CONSOLE int = 1 /// console device
 	// UNIX domain sockets
-	D_SUD     = 2
-	D_SUS     = 3
-	D_DEVNULL = 4
-	D_RAWDISK = 5
-	D_STAT    = 6
-	D_PROF    = 7
-	D_FIRST   = D_CONSOLE
-	D_LAST    = D_SUS
+	D_SUD     = 2         /// datagram socket device
+	D_SUS     = 3         /// stream socket device
+	D_DEVNULL = 4         /// /dev/null sink
+	D_RAWDISK = 5         /// raw disk interface
+	D_STAT    = 6         /// statistics device
+	D_PROF    = 7         /// profiling device
+	D_FIRST   = D_CONSOLE /// lowest device number
+	D_LAST    = D_SUS     /// highest device number
 )
 
+// / Mkdev encodes a major and minor device number into a 64-bit identifier.
 func Mkdev(_maj, _min int) uint {
 	maj := uint(_maj)
 	min := uint(_min)
@@ -23,6 +25,7 @@ func Mkdev(_maj, _min int) uint {
 	return uint(m << 32)
 }
 
+// / Unmkdev returns the major and minor components of a device number.
 func Unmkdev(d uint) (int, int) {
 	return int(d >> 40), int(uint8(d >> 32))
 }

--- a/biscuit/src/defs/errno.go
+++ b/biscuit/src/defs/errno.go
@@ -1,5 +1,7 @@
 package defs
 
+// / Posix-style error numbers returned by system calls.
+
 const (
 	EPERM         Err_t = 1
 	ENOENT        Err_t = 2
@@ -47,4 +49,5 @@ const (
 	ENOHEAP       Err_t = 511
 )
 
+// / Err_t represents a system call error number.
 type Err_t int

--- a/biscuit/src/defs/syscall.go
+++ b/biscuit/src/defs/syscall.go
@@ -1,6 +1,9 @@
 package defs
 
+// / Msgfl_t represents ancillary message flags.
 type Msgfl_t uint
+
+// / Fdopt_t encodes open(2) file descriptor options.
 type Fdopt_t uint
 
 const (
@@ -170,6 +173,7 @@ const (
 	SIGKILL = 9
 )
 
+// / Mkexitsig converts a signal number to the encoded exit status form.
 func Mkexitsig(sig int) int {
 	if sig < 0 || sig > 32 {
 		panic("bad sig")

--- a/biscuit/src/fd/fd.go
+++ b/biscuit/src/fd/fd.go
@@ -7,12 +7,14 @@ import "defs"
 import "fdops"
 import "ustr"
 
+// / File descriptor permission bits.
 const (
-	FD_READ    = 0x1
-	FD_WRITE   = 0x2
-	FD_CLOEXEC = 0x4
+	FD_READ    = 0x1 /// read permission
+	FD_WRITE   = 0x2 /// write permission
+	FD_CLOEXEC = 0x4 /// close-on-exec flag
 )
 
+// / Fd_t represents an open file descriptor.
 type Fd_t struct {
 	// fops is an interface implemented via a "pointer receiver", thus fops
 	// is a reference, not a value
@@ -20,6 +22,7 @@ type Fd_t struct {
 	Perms int
 }
 
+// / Copyfd duplicates an open file descriptor by reopening it.
 func Copyfd(fd *Fd_t) (*Fd_t, defs.Err_t) {
 	nfd := &Fd_t{}
 	*nfd = *fd
@@ -30,18 +33,21 @@ func Copyfd(fd *Fd_t) (*Fd_t, defs.Err_t) {
 	return nfd, 0
 }
 
+// / Close_panic closes the descriptor and panics on failure.
 func Close_panic(f *Fd_t) {
 	if f.Fops.Close() != 0 {
 		panic("must succeed")
 	}
 }
 
+// / Cwd_t tracks the current working directory for a process.
 type Cwd_t struct {
 	sync.Mutex // to serialize chdirs
 	Fd         *Fd_t
 	Path       ustr.Ustr
 }
 
+// / Fullpath joins cwd with p if p is not already absolute.
 func (cwd *Cwd_t) Fullpath(p ustr.Ustr) ustr.Ustr {
 	if p.IsAbsolute() {
 		return p
@@ -51,11 +57,13 @@ func (cwd *Cwd_t) Fullpath(p ustr.Ustr) ustr.Ustr {
 	}
 }
 
+// / Canonicalpath resolves path components relative to cwd.
 func (cwd *Cwd_t) Canonicalpath(p ustr.Ustr) ustr.Ustr {
 	p1 := cwd.Fullpath(p)
 	return bpath.Canonicalize(p1)
 }
 
+// / MkRootCwd constructs a Cwd_t rooted at "/".
 func MkRootCwd(fd *Fd_t) *Cwd_t {
 	c := &Cwd_t{}
 	c.Fd = fd

--- a/biscuit/src/fs/dir.go
+++ b/biscuit/src/fs/dir.go
@@ -12,6 +12,7 @@ import "res"
 import "ustr"
 import "util"
 
+// / NAME_MAX is the longest valid file name length.
 const NAME_MAX int = 512
 
 var lhits = 0
@@ -120,8 +121,8 @@ type icdent_t struct {
 	offset int
 	inum   defs.Inum_t
 	// idm may be nil since it is lazily filled on ilookup
-	idm    *imemnode_t
-	name   ustr.Ustr
+	idm  *imemnode_t
+	name ustr.Ustr
 }
 
 func (de *icdent_t) String() string {


### PR DESCRIPTION
## Summary
- document device number helpers
- add comments for errno definitions
- describe syscall types and helpers
- document fd package structures and helpers
- document fdops poll helpers
- describe block device structures and helpers
- document cache structures and helpers
- document NAME_MAX constant

## Testing
- `gofmt -w biscuit/src/defs/device.go biscuit/src/defs/errno.go biscuit/src/defs/syscall.go biscuit/src/fd/fd.go biscuit/src/fdops/fdops.go biscuit/src/fs/blk.go biscuit/src/fs/cache.go biscuit/src/fs/dir.go`
- `go test ./...` *(fails: package references not in std, missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6848fd11c13c833196a690a118efdab1

## Summary by Sourcery

Add GoDoc comments to exported symbols across multiple packages to improve code documentation and clarity

Enhancements:
- Document device number constants and helper functions in defs
- Add comments for Posix errno definitions in defs
- Document syscall option types and helper functions in defs
- Document file descriptor types, constants, and helpers in fd package
- Document polling interfaces and helpers in fdops package
- Document block device interfaces, types, and and helper functions in fs/blk package
- Document cache interface, types, and eviction helpers in fs/cache package
- Document directory constants, including NAME_MAX, in fs/dir package