### PR TITLE
Improve VM documentation

### DIFF
--- a/biscuit/src/vm/as.go
+++ b/biscuit/src/vm/as.go
@@ -11,8 +11,11 @@ import "fdops"
 import "mem"
 import "res"
 import "ustr"
+
 import "util"
 
+// / Vm_t represents a process address space. The mutex protects
+// / modifications to Vmregion, Pmap, and P_pmap.
 type Vm_t struct {
 	// lock for vmregion, pmpages, pmap, and p_pmap
 	sync.Mutex
@@ -26,6 +29,8 @@ type Vm_t struct {
 	pgfltaken bool
 }
 
+// / Lock_pmap acquires the address space mutex and marks that a page
+// / fault is being handled.
 func (as *Vm_t) Lock_pmap() {
 	// useful for finding deadlock bugs with one cpu
 	//if p.pgfltaken {
@@ -35,17 +40,23 @@ func (as *Vm_t) Lock_pmap() {
 	as.pgfltaken = true
 }
 
+// / Unlock_pmap releases the address space mutex after page table
+// / manipulation is complete.
 func (as *Vm_t) Unlock_pmap() {
 	as.pgfltaken = false
 	as.Unlock()
 }
 
+// / Lockassert_pmap panics if the address space mutex is not held.
 func (as *Vm_t) Lockassert_pmap() {
 	if !as.pgfltaken {
 		panic("pgfl lock must be held")
 	}
 }
 
+// / Userdmap8_inner returns a slice mapping of the user address at va.
+// / When k2u is true the memory will be prepared for a kernel write.
+// / It returns the mapped slice or an error code.
 func (as *Vm_t) Userdmap8_inner(va int, k2u bool) ([]uint8, defs.Err_t) {
 	as.Lockassert_pmap()
 
@@ -100,6 +111,8 @@ func (as *Vm_t) _userdmap8(va int, k2u bool) ([]uint8, defs.Err_t) {
 	return ret, err
 }
 
+// / Userdmap8r maps the user address for reading and returns the
+// / resulting slice or an error.
 func (as *Vm_t) Userdmap8r(va int) ([]uint8, defs.Err_t) {
 	return as._userdmap8(va, false)
 }
@@ -112,6 +125,8 @@ func (as *Vm_t) usermapped(va, n int) bool {
 	return ok
 }
 
+// / Userreadn reads n bytes from the user address va and returns the
+// / value and any error encountered.
 func (as *Vm_t) Userreadn(va, n int) (int, defs.Err_t) {
 	as.Lock_pmap()
 	a, b := as.userreadn_inner(va, n)
@@ -142,6 +157,8 @@ func (as *Vm_t) userreadn_inner(va, n int) (int, defs.Err_t) {
 	return ret, 0
 }
 
+// / Userwriten writes n bytes of val to the user address va. It
+// / returns an error code if the copy fails.
 func (as *Vm_t) Userwriten(va, n, val int) defs.Err_t {
 	if n > 8 {
 		panic("large n")
@@ -161,7 +178,8 @@ func (as *Vm_t) Userwriten(va, n, val int) defs.Err_t {
 	return 0
 }
 
-// first ret value is the string from user space second is error
+// / Userstr copies a NUL terminated string from user space up to
+// / lenmax bytes. It returns the copied string and an error code.
 func (as *Vm_t) Userstr(uva int, lenmax int) (ustr.Ustr, defs.Err_t) {
 	if lenmax < 0 {
 		return nil, 0
@@ -194,6 +212,8 @@ func (as *Vm_t) Userstr(uva int, lenmax int) (ustr.Ustr, defs.Err_t) {
 	}
 }
 
+// / Usertimespec reads a timeval structure from user memory at va
+// / and returns both the duration and time value.
 func (as *Vm_t) Usertimespec(va int) (time.Duration, time.Time, defs.Err_t) {
 	var zt time.Time
 	secs, err := as.Userreadn(va, 8)
@@ -213,8 +233,8 @@ func (as *Vm_t) Usertimespec(va int) (time.Duration, time.Time, defs.Err_t) {
 	return tot, t, 0
 }
 
-// copies src to the user virtual address uva. may copy part of src if uva +
-// len(src) is not mapped
+// / K2user copies src into the user virtual address space starting at
+// / uva. The copy may be partial if the region is not fully mapped.
 func (as *Vm_t) K2user(src []uint8, uva int) defs.Err_t {
 	as.Lock_pmap()
 	ret := as.K2user_inner(src, uva)
@@ -246,7 +266,8 @@ func (as *Vm_t) K2user_inner(src []uint8, uva int) defs.Err_t {
 	return 0
 }
 
-// copies len(dst) bytes from userspace address uva to dst
+// / User2k copies len(dst) bytes from the user virtual address uva
+// / into dst. It returns an error code if the read fails.
 func (as *Vm_t) User2k(dst []uint8, uva int) defs.Err_t {
 	as.Lock_pmap()
 	ret := as.User2k_inner(dst, uva)
@@ -293,10 +314,14 @@ func (as *Vm_t) Unusedva_inner(startva, len int) int {
 
 var _numtoapicid func(int) uint32
 
+// / Cpumap records a helper that converts CPU IDs to APIC IDs for
+// / TLB shootdown broadcast.
 func Cpumap(f func(int) uint32) {
 	_numtoapicid = f
 }
 
+// / Tlbshoot invalidates pgcount pages starting at startva on all CPUs
+// / that have this pmap loaded.
 func (as *Vm_t) Tlbshoot(startva uintptr, pgcount int) {
 	if pgcount == 0 {
 		return
@@ -320,7 +345,9 @@ func (as *Vm_t) Tlbshoot(startva uintptr, pgcount int) {
 	tlb_shootdown(as.P_pmap, tlbp, startva, pgcount)
 }
 
-// returns true if the fault was handled successfully
+// / Sys_pgfault resolves a page fault for the address space as at the
+// / given fault address with the provided error code. It returns an
+// / error code describing the result.
 func Sys_pgfault(as *Vm_t, vmi *Vminfo_t, faultaddr, ecode uintptr) defs.Err_t {
 	isguard := vmi.Perms == 0
 	iswrite := ecode&uintptr(PTE_W) != 0
@@ -441,7 +468,7 @@ func Sys_pgfault(as *Vm_t, vmi *Vminfo_t, faultaddr, ecode uintptr) defs.Err_t {
 			perms |= PTE_COW
 		}
 	}
-	if perms & PTE_W != 0 {
+	if perms&PTE_W != 0 {
 		perms |= PTE_D
 	}
 	perms |= PTE_A
@@ -466,6 +493,9 @@ func Sys_pgfault(as *Vm_t, vmi *Vminfo_t, faultaddr, ecode uintptr) defs.Err_t {
 // to flush TLB). the second return value is false if the page insertion failed
 // due to lack of user pages. p_pg's ref count is increased so the caller can
 // simply Physmem.Refdown()
+// / Page_insert maps the physical page p_pg at va with perms. The
+// / function returns whether an existing mapping was replaced and
+// / whether the insertion succeeded.
 func (as *Vm_t) Page_insert(va int, p_pg mem.Pa_t, perms mem.Pa_t,
 	vempty bool, pte *mem.Pa_t) (bool, bool) {
 	return as._page_insert(va, p_pg, perms, vempty, true, pte)
@@ -475,6 +505,8 @@ func (as *Vm_t) Page_insert(va int, p_pg mem.Pa_t, perms mem.Pa_t,
 // to flush TLB). the second return value is false if the page insertion failed
 // due to lack of user pages. p_pg's ref count is increased so the caller can
 // simply Physmem.Refdown()
+// / Blockpage_insert adds a page mapping without increasing the
+// / reference count of p_pg. It is used for block pages.
 func (as *Vm_t) Blockpage_insert(va int, p_pg mem.Pa_t, perms mem.Pa_t,
 	vempty bool, pte *mem.Pa_t) (bool, bool) {
 	return as._page_insert(va, p_pg, perms, vempty, false, pte)
@@ -512,6 +544,8 @@ func (as *Vm_t) _page_insert(va int, p_pg mem.Pa_t, perms mem.Pa_t,
 	return ninval, true
 }
 
+// / Page_remove unmaps the page at va from this address space and
+// / returns true if a mapping was removed.
 func (as *Vm_t) Page_remove(va int) bool {
 	as.Lockassert_pmap()
 	remmed := false
@@ -528,7 +562,9 @@ func (as *Vm_t) Page_remove(va int) bool {
 	return remmed
 }
 
-// returns true if the pagefault was handled successfully
+// / Pgfault handles a page fault triggered by tid for the given fault
+// / address and error code. It returns an error describing the
+// / outcome.
 func (as *Vm_t) Pgfault(tid defs.Tid_t, fa, ecode uintptr) defs.Err_t {
 	as.Lock_pmap()
 	vmi, ok := as.Vmregion.Lookup(fa)
@@ -541,6 +577,8 @@ func (as *Vm_t) Pgfault(tid defs.Tid_t, fa, ecode uintptr) defs.Err_t {
 	return ret
 }
 
+// / Uvmfree releases all user mappings and page tables associated
+// / with this address space.
 func (as *Vm_t) Uvmfree() {
 	Uvmfree_inner(as.Pmap, as.P_pmap, &as.Vmregion)
 	// Dec_pmap could free the pmap itself. thus it must come after
@@ -550,22 +588,32 @@ func (as *Vm_t) Uvmfree() {
 	as.Vmregion.Clear()
 }
 
+// / Vmadd_anon creates a private anonymous mapping at the given
+// / virtual address range with the supplied permissions.
 func (as *Vm_t) Vmadd_anon(start, len int, perms mem.Pa_t) {
 	vmi := as._mkvmi(VANON, start, len, perms, 0, nil, nil)
 	as.Vmregion.insert(vmi)
 }
 
+// / Vmadd_file maps a region backed by the provided file operations
+// / at the specified offset. The mapping may be shared or private
+// / depending on the supplied operations.
 func (as *Vm_t) Vmadd_file(start, len int, perms mem.Pa_t, fops fdops.Fdops_i,
 	foff int) {
 	vmi := as._mkvmi(VFILE, start, len, perms, foff, fops, nil)
 	as.Vmregion.insert(vmi)
 }
 
+// / Vmadd_shareanon inserts a shared anonymous mapping with the given
+// / permissions.
 func (as *Vm_t) Vmadd_shareanon(start, len int, perms mem.Pa_t) {
 	vmi := as._mkvmi(VSANON, start, len, perms, 0, nil, nil)
 	as.Vmregion.insert(vmi)
 }
 
+// / Vmadd_sharefile creates a shared file-backed mapping using fops
+// / starting at the given offset. The unpin callback is used when
+// / unmapping pages.
 func (as *Vm_t) Vmadd_sharefile(start, len int, perms mem.Pa_t, fops fdops.Fdops_i,
 	foff int, unpin mem.Unpin_i) {
 	vmi := as._mkvmi(VFILE, start, len, perms, foff, fops, unpin)
@@ -606,6 +654,8 @@ func (as *Vm_t) _mkvmi(mt mtype_t, start, len int, perms mem.Pa_t, foff int,
 	return ret
 }
 
+// / Mkuserbuf allocates and initializes a Userbuf_t referencing user
+// / memory starting at userva.
 func (as *Vm_t) Mkuserbuf(userva, len int) *Userbuf_t {
 	ret := &Userbuf_t{}
 	ret.ub_init(as, userva, len)

--- a/biscuit/src/vm/rb.go
+++ b/biscuit/src/vm/rb.go
@@ -1,5 +1,6 @@
 package vm
 
+// / Rbc_t represents a red-black color.
 type Rbc_t int
 
 const (
@@ -7,10 +8,12 @@ const (
 	BLACK Rbc_t = iota
 )
 
+// / Rbh_t is a red-black tree head containing the root node.
 type Rbh_t struct {
 	root *Rbn_t
 }
 
+// / Rbn_t is a node in the virtual memory red-black tree.
 type Rbn_t struct {
 	p   *Rbn_t
 	r   *Rbn_t

--- a/biscuit/src/vm/vm.go
+++ b/biscuit/src/vm/vm.go
@@ -9,6 +9,8 @@ import "util"
 
 //import "fd"
 
+/// Page table entry flags used by the virtual memory system.
+
 const PTE_P mem.Pa_t = 1 << 0
 const PTE_W mem.Pa_t = 1 << 1
 const PTE_U mem.Pa_t = 1 << 2
@@ -22,6 +24,7 @@ const PTE_PS mem.Pa_t = 1 << 7
 const PTE_COW mem.Pa_t = 1 << 9
 const PTE_WASCOW mem.Pa_t = 1 << 10
 
+// / Constants describing page size and address calculations.
 const PGSIZEW uintptr = uintptr(mem.PGSIZE)
 const PGSHIFT uint = 12
 const PGOFFSET mem.Pa_t = 0xfff
@@ -33,7 +36,7 @@ const PTE_FLAGS mem.Pa_t = (PTE_P | PTE_W | PTE_U | PTE_PCD | PTE_PS | PTE_COW |
 
 type mtype_t uint
 
-// types of mappings
+// / Types of supported memory mappings.
 const (
 	VANON mtype_t = 1 << iota
 	// shared or private file
@@ -42,6 +45,7 @@ const (
 	VSANON mtype_t = 1 << iota
 )
 
+// / Mfile_t tracks a file-backed mapping within an address space.
 type Mfile_t struct {
 	mfops fdops.Fdops_i
 	unpin mem.Unpin_i
@@ -49,6 +53,7 @@ type Mfile_t struct {
 	mapcount int
 }
 
+// / Vminfo_t describes a contiguous range of virtual memory.
 type Vminfo_t struct {
 	Mtype mtype_t
 	Pgn   uintptr
@@ -62,6 +67,7 @@ type Vminfo_t struct {
 	pch []mem.Pa_t
 }
 
+// / Vmregion_t manages all virtual memory mappings using a red-black tree.
 type Vmregion_t struct {
 	rb     Rbh_t
 	_pglen int
@@ -72,7 +78,8 @@ type Vmregion_t struct {
 	}
 }
 
-// if err == 0, the FS increased the reference count on the page.
+// / Filepage returns the file page backing va. The file system
+// / increases the reference count on success.
 func (vmi *Vminfo_t) Filepage(va uintptr) (*mem.Pg_t, mem.Pa_t, defs.Err_t) {
 	if vmi.Mtype != VFILE {
 		panic("must be file mapping")
@@ -86,6 +93,8 @@ func (vmi *Vminfo_t) Filepage(va uintptr) (*mem.Pg_t, mem.Pa_t, defs.Err_t) {
 	return mmapi[0].Pg, mmapi[0].Phys, 0
 }
 
+// / Ptefor returns the page table entry pointer for va in pmap,
+// / allocating intermediate tables as necessary.
 func (vmi *Vminfo_t) Ptefor(pmap *mem.Pmap_t, va uintptr) (*mem.Pa_t, bool) {
 	if vmi.pch == nil {
 		bva := int(vmi.Pgn) << PGSHIFT
@@ -264,12 +273,14 @@ func (m *Vmregion_t) _clear(vmi *Vminfo_t, pglen int) {
 	}
 }
 
+// / Clear closes all file mappings and resets the region set.
 func (m *Vmregion_t) Clear() {
 	m.Iter(func(vmi *Vminfo_t) {
 		m._clear(vmi, vmi.Pglen)
 	})
 }
 
+// / Lookup returns the mapping containing the given virtual address.
 func (m *Vmregion_t) Lookup(va uintptr) (*Vminfo_t, bool) {
 	pgn := va >> PGSHIFT
 	n := m.rb.lookup(pgn)
@@ -300,6 +311,7 @@ func (m *Vmregion_t) _copy1(par, src *Rbn_t) *Rbn_t {
 	return ret
 }
 
+// / Copy duplicates all mappings and returns a new Vmregion_t.
 func (m *Vmregion_t) Copy() Vmregion_t {
 	var ret Vmregion_t
 	ret._pglen, ret.Novma = m._pglen, m.Novma
@@ -362,10 +374,12 @@ func (m *Vmregion_t) _iter1(n *Rbn_t, f func(*Vminfo_t)) {
 	m._iter1(n.r, f)
 }
 
+// / Iter walks every mapping in order and invokes f.
 func (m *Vmregion_t) Iter(f func(*Vminfo_t)) {
 	m._iter1(m.rb.root, f)
 }
 
+// / Pglen returns the total number of pages mapped.
 func (m *Vmregion_t) Pglen() int {
 	return m._pglen
 }
@@ -425,6 +439,8 @@ func (m *Vmregion_t) end() uintptr {
 	return last << PGSHIFT
 }
 
+// / Remove unmaps the specified range from the region set. novma limits
+// / the number of VMA objects that may remain.
 func (m *Vmregion_t) Remove(start, len int, novma uint) defs.Err_t {
 	pgn := uintptr(start) >> PGSHIFT
 	pglen := util.Roundup(len, mem.PGSIZE) >> PGSHIFT


### PR DESCRIPTION
## Summary
- document exported VM functions and data structures
- polish comments about page map utilities and user buffers
- clean up comment spacing

## Testing
- `gofmt -w biscuit/src/vm/as.go biscuit/src/vm/pmap.go biscuit/src/vm/rb.go biscuit/src/vm/userbuf.go biscuit/src/vm/vm.go`

------
https://chatgpt.com/codex/tasks/task_e_6848fd162b8c8331bae936ff9b631bba