### PR TITLE
Fix comment style

### DIFF
--- a/biscuit/src/circbuf/circbuf.go
+++ b/biscuit/src/circbuf/circbuf.go
@@ -4,8 +4,8 @@ import "defs"
 import "fdops"
 import "mem"
 
-// / Circbuf_t implements a simple circular buffer used by a single daemon.
-// / It is not safe for concurrent use and references no global variables.
+/// Circbuf_t implements a simple circular buffer used by a single daemon.
+/// It is not safe for concurrent use and references no global variables.
 type Circbuf_t struct {
 	mem   mem.Page_i /// page allocator interface
 	Buf   []uint8    /// underlying buffer backing memory
@@ -15,17 +15,16 @@ type Circbuf_t struct {
 	p_pg  mem.Pa_t   /// physical page backing the buffer
 }
 
-// / Bufsz returns the configured buffer size.
+/// Bufsz returns the configured buffer size.
 func (cb *Circbuf_t) Bufsz() int {
 	return cb.bufsz
 }
 
-// / Set provides an existing byte slice and page allocator.
-// /
-// / Parameters:
-// /   nb  - backing byte slice.
-// /   did - initial head index.
-// /   m   - page allocator.
+/// Set provides an existing byte slice and page allocator.
+/// Parameters:
+///   nb  - backing byte slice.
+///   did - initial head index.
+///   m   - page allocator.
 func (cb *Circbuf_t) Set(nb []uint8, did int, m mem.Page_i) {
 	cb.mem = m
 	cb.Buf = nb
@@ -34,13 +33,11 @@ func (cb *Circbuf_t) Set(nb []uint8, did int, m mem.Page_i) {
 	cb.tail = 0
 }
 
-// / Cb_init lazily allocates a backing page when required.
-// /
-// / Parameters:
-// /   sz - buffer size in bytes.
-// /   m  - page allocator.
-// /
-// / Returns ENOMEM on allocation failure.
+/// Cb_init lazily allocates a backing page when required.
+/// Parameters:
+///   sz - buffer size in bytes.
+///   m  - page allocator.
+/// Returns ENOMEM on allocation failure.
 func (cb *Circbuf_t) Cb_init(sz int, m mem.Page_i) defs.Err_t {
 	bufmax := int(mem.PGSIZE)
 	if sz <= 0 || sz > bufmax {
@@ -55,12 +52,11 @@ func (cb *Circbuf_t) Cb_init(sz int, m mem.Page_i) defs.Err_t {
 	return 0
 }
 
-// / Cb_init_phys supplies a preallocated page backing the buffer.
-// /
-// / Parameters:
-// /   v   - byte slice mapping the page.
-// /   p_pg- physical page address.
-// /   m   - page allocator.
+/// Cb_init_phys supplies a preallocated page backing the buffer.
+/// Parameters:
+///   v   - byte slice mapping the page.
+///   p_pg- physical page address.
+///   m   - page allocator.
 func (cb *Circbuf_t) Cb_init_phys(v []uint8, p_pg mem.Pa_t, m mem.Page_i) {
 	cb.mem = m
 	cb.mem.Refup(p_pg)
@@ -70,7 +66,7 @@ func (cb *Circbuf_t) Cb_init_phys(v []uint8, p_pg mem.Pa_t, m mem.Page_i) {
 	cb.head, cb.tail = 0, 0
 }
 
-// / Cb_release drops the reference to the backing page.
+/// Cb_release drops the reference to the backing page.
 func (cb *Circbuf_t) Cb_release() {
 	if cb.Buf == nil {
 		return
@@ -81,10 +77,9 @@ func (cb *Circbuf_t) Cb_release() {
 	cb.head, cb.tail = 0, 0
 }
 
-// / Cb_ensure guarantees that the buffer is allocated.
-// /
-// / Return value:
-// /   defs.Err_t - ENOMEM if allocation fails.
+/// Cb_ensure guarantees that the buffer is allocated.
+/// Return value:
+///   defs.Err_t - ENOMEM if allocation fails.
 func (cb *Circbuf_t) Cb_ensure() defs.Err_t {
 	if cb.Buf != nil {
 		return 0
@@ -102,34 +97,33 @@ func (cb *Circbuf_t) Cb_ensure() defs.Err_t {
 	return 0
 }
 
-// / Full returns true when the buffer cannot accept more data.
+/// Full returns true when the buffer cannot accept more data.
 func (cb *Circbuf_t) Full() bool {
 	return cb.head-cb.tail == cb.bufsz
 }
 
-// / Empty reports whether the buffer contains any data.
+/// Empty reports whether the buffer contains any data.
 func (cb *Circbuf_t) Empty() bool {
 	return cb.head == cb.tail
 }
 
-// / Left returns the remaining capacity in bytes.
+/// Left returns the remaining capacity in bytes.
 func (cb *Circbuf_t) Left() int {
 	used := cb.head - cb.tail
 	rem := cb.bufsz - used
 	return rem
 }
 
-// / Used returns the current number of bytes in the buffer.
+/// Used returns the current number of bytes in the buffer.
 func (cb *Circbuf_t) Used() int {
 	used := cb.head - cb.tail
 	return used
 }
 
-// / Copyin reads from src into the circular buffer.
-// /
-// / Return values:
-// /   int       - bytes written.
-// /   defs.Err_t- error code on failure.
+/// Copyin reads from src into the circular buffer.
+/// Return values:
+///   int       - bytes written.
+///   defs.Err_t- error code on failure.
 func (cb *Circbuf_t) Copyin(src fdops.Userio_i) (int, defs.Err_t) {
 	if err := cb.Cb_ensure(); err != 0 {
 		return 0, err
@@ -168,16 +162,15 @@ func (cb *Circbuf_t) Copyin(src fdops.Userio_i) (int, defs.Err_t) {
 	return c, 0
 }
 
-// / Copyout writes the entire buffer contents to dst.
+/// Copyout writes the entire buffer contents to dst.
 func (cb *Circbuf_t) Copyout(dst fdops.Userio_i) (int, defs.Err_t) {
 	return cb.Copyout_n(dst, 0)
 }
 
-// / Copyout_n writes up to max bytes of the buffer to dst.
-// /
-// / Return values:
-// /   int       - bytes written.
-// /   defs.Err_t- error code on failure.
+/// Copyout_n writes up to max bytes of the buffer to dst.
+/// Return values:
+///   int       - bytes written.
+///   defs.Err_t- error code on failure.
 func (cb *Circbuf_t) Copyout_n(dst fdops.Userio_i, max int) (int, defs.Err_t) {
 	if err := cb.Cb_ensure(); err != 0 {
 		return 0, err
@@ -225,8 +218,8 @@ func (cb *Circbuf_t) Copyout_n(dst fdops.Userio_i, max int) (int, defs.Err_t) {
 	return c, 0
 }
 
-// / Rawwrite exposes a slice for writing directly to the buffer.
-// / It returns up to two slices when the region wraps.
+/// Rawwrite exposes a slice for writing directly to the buffer.
+/// It returns up to two slices when the region wraps.
 func (cb *Circbuf_t) Rawwrite(offset, sz int) ([]uint8, []uint8) {
 	if cb.Buf == nil {
 		panic("no lazy allocation for tcp")
@@ -263,7 +256,7 @@ func (cb *Circbuf_t) Rawwrite(offset, sz int) ([]uint8, []uint8) {
 	return r1, r2
 }
 
-// / Advhead advances the head index allowing previously written bytes to be read.
+/// Advhead advances the head index allowing previously written bytes to be read.
 func (cb *Circbuf_t) Advhead(sz int) {
 	if cb.Full() || cb.Left() < sz {
 		panic("advancing full cb")
@@ -271,8 +264,8 @@ func (cb *Circbuf_t) Advhead(sz int) {
 	cb.head += sz
 }
 
-// / Rawread returns slices referencing the buffer starting at offset.
-// / It may return two slices when the data wraps.
+/// Rawread returns slices referencing the buffer starting at offset.
+/// It may return two slices when the data wraps.
 func (cb *Circbuf_t) Rawread(offset int) ([]uint8, []uint8) {
 	if cb.Buf == nil {
 		panic("no lazy allocation for tcp")
@@ -303,7 +296,7 @@ func (cb *Circbuf_t) Rawread(offset int) ([]uint8, []uint8) {
 	return r1, r2
 }
 
-// / Advtail advances the tail index after data has been consumed.
+/// Advtail advances the tail index after data has been consumed.
 func (cb *Circbuf_t) Advtail(sz int) {
 	if sz != 0 && (cb.Empty() || cb.Used() < sz) {
 		panic("advancing empty cb")

--- a/biscuit/src/hashtable/hashtable.go
+++ b/biscuit/src/hashtable/hashtable.go
@@ -9,7 +9,7 @@ import "unsafe"
 
 import "ustr"
 
-// A hashtable with a lock-free Get()
+//A hashtable with a lock-free Get()
 
 type hashtable_i interface {
 	Get(key interface{}) (interface{}, bool)
@@ -61,18 +61,17 @@ func (b *bucket_t) iter(f func(interface{}, interface{}) bool) bool {
 	return false
 }
 
-// /   Hashtable_t represents a basic hash table mapping keys to values.
-// /   It is protected internally by bucket locks.
+// / Hashtable_t represents a basic hash table mapping keys to values.
+// / It is protected internally by bucket locks.
 type Hashtable_t struct {
 	table    []*bucket_t
 	capacity int
 	maxchain int
 }
 
-// /   MkHash allocates a new Hashtable_t with the given size.
-// /
-// /   \param size number of buckets to allocate
-// /   \return pointer to an initialized Hashtable_t.
+// / MkHash allocates a new Hashtable_t with the given size.
+// / \param size number of buckets to allocate
+// / \return pointer to an initialized Hashtable_t.
 func MkHash(size int) *Hashtable_t {
 	ht := &Hashtable_t{}
 	ht.capacity = size
@@ -84,9 +83,8 @@ func MkHash(size int) *Hashtable_t {
 	return ht
 }
 
-// /   String returns a formatted representation of the table contents.
-// /
-// /   \return string description of bucket chains.
+// / String returns a formatted representation of the table contents.
+// / \return string description of bucket chains.
 func (ht *Hashtable_t) String() string {
 	s := ""
 	for i, b := range ht.table {
@@ -101,9 +99,8 @@ func (ht *Hashtable_t) String() string {
 	return s
 }
 
-// /   Size returns the total number of elements stored in the table.
-// /
-// /   \return element count.
+// / Size returns the total number of elements stored in the table.
+// / \return element count.
 func (ht *Hashtable_t) Size() int {
 	n := 0
 	for _, b := range ht.table {
@@ -112,15 +109,14 @@ func (ht *Hashtable_t) Size() int {
 	return n
 }
 
-// /   Pair_t represents a key/value tuple returned by Elems.
+// / Pair_t represents a key/value tuple returned by Elems.
 type Pair_t struct {
 	Key   interface{}
 	Value interface{}
 }
 
-// /   Elems returns all key/value pairs currently stored.
-// /
-// /   \return slice of Pair_t containing each element.
+// / Elems returns all key/value pairs currently stored.
+// / \return slice of Pair_t containing each element.
 func (ht *Hashtable_t) Elems() []Pair_t {
 	p := make([]Pair_t, 0)
 	for _, b := range ht.table {
@@ -132,10 +128,9 @@ func (ht *Hashtable_t) Elems() []Pair_t {
 	return p
 }
 
-// /   Get looks up the provided key and returns its value.
-// /
-// /   \param key value to search for
-// /   \return stored value and true when found.
+// / Get looks up the provided key and returns its value.
+// / \param key value to search for
+// / \return stored value and true when found.
 func (ht *Hashtable_t) Get(key interface{}) (interface{}, bool) {
 	kh := khash(key)
 	b := ht.table[ht.hash(kh)]
@@ -156,11 +151,10 @@ func (ht *Hashtable_t) Get(key interface{}) (interface{}, bool) {
 	return nil, false
 }
 
-// /   GetRLock performs Get while holding a read lock.
-// /   Used only for performance comparisons.
-// /
-// /   \param key value to search for
-// /   \return stored value and true when found.
+// / GetRLock performs Get while holding a read lock.
+// / Used only for performance comparisons.
+// / \param key value to search for
+// / \return stored value and true when found.
 func (ht *Hashtable_t) GetRLock(key interface{}) (interface{}, bool) {
 	kh := khash(key)
 	b := ht.table[ht.hash(kh)]
@@ -184,11 +178,10 @@ func (ht *Hashtable_t) GetRLock(key interface{}) (interface{}, bool) {
 	return nil, false
 }
 
-// /   Set inserts a key/value pair and returns false if the key already existed.
-// /
-// /   \param key identifier
-// /   \param value data to store
-// /   \return previous value and true when inserted.
+// / Set inserts a key/value pair and returns false if the key already existed.
+// / \param key identifier
+// / \param value data to store
+// / \return previous value and true when inserted.
 func (ht *Hashtable_t) Set(key interface{}, value interface{}) (interface{}, bool) {
 	kh := khash(key)
 	b := ht.table[ht.hash(kh)]
@@ -220,9 +213,8 @@ func (ht *Hashtable_t) Set(key interface{}, value interface{}) (interface{}, boo
 	return value, true
 }
 
-// /   Del removes a key from the table.
-// /
-// /   \param key identifier to delete
+// / Del removes a key from the table.
+// / \param key identifier to delete
 func (ht *Hashtable_t) Del(key interface{}) {
 	kh := khash(key)
 	b := ht.table[ht.hash(kh)]
@@ -253,11 +245,10 @@ func (ht *Hashtable_t) Del(key interface{}) {
 	panic("del of non-existing key")
 }
 
-// /   Iter applies f to each key/value pair.
-// /
-// /   Iteration stops when f returns true.
-// /   \param f visitor function
-// /   \return true if f returned true for any element.
+// / Iter applies f to each key/value pair.
+// / Iteration stops when f returns true.
+// / \param f visitor function
+// / \return true if f returned true for any element.
 func (ht *Hashtable_t) Iter(f func(interface{}, interface{}) bool) bool {
 	for _, b := range ht.table {
 		if b.iter(f) {


### PR DESCRIPTION
## Summary
- standardize comment markers in circbuf
- adjust hashtable comment spacing

## Testing
- `go vet ./...` *(fails: package not in std)*

------
https://chatgpt.com/codex/tasks/task_e_6849da9faae48331b17f555a23393e4e