### PR TITLE
Add /// docs for exported API

### DIFF
--- a/biscuit/src/fs/fs.go
+++ b/biscuit/src/fs/fs.go
@@ -23,8 +23,8 @@ const iroot = defs.Inum_t(0)
 
 var cons proc.Cons_i
 
-// / Fs_t holds the in-memory state of the filesystem including caches,
-// / logging structures and allocation information.
+// /       Fs_t holds the in-memory state of the filesystem including caches,
+// /       logging structures and allocation information.
 type Fs_t struct {
 	ahci         Disk_i
 	superb_start int
@@ -39,8 +39,8 @@ type Fs_t struct {
 	diskfs       bool // disk or in-mem file system?
 }
 
-// / StartFS sets up and returns a new file system.  It exposes the root as a
-// / file descriptor and returns the initialized Fs_t structure.
+// /       StartFS sets up and returns a new file system.  It exposes the root as a
+// /       file descriptor and returns the initialized Fs_t structure.
 func StartFS(mem Blockmem_i, disk Disk_i, console proc.Cons_i, diskfs bool) (*fd.Fd_t, *Fs_t) {
 
 	if mem == nil || disk == nil || console == nil {
@@ -113,42 +113,42 @@ func StartFS(mem Blockmem_i, disk Disk_i, console proc.Cons_i, diskfs bool) (*fd
 	return &fd.Fd_t{Fops: &fsfops_t{priv: iroot, fs: fs, count: 1}}, fs
 }
 
-// / Sizes returns the number of cached inodes and blocks.
+// /       Sizes returns the number of cached inodes and blocks.
 func (fs *Fs_t) Sizes() (int, int) {
 	return fs.icache.cache.Len(), fs.bcache.cache.Len()
 }
 
-// / StopFS shuts down the log associated with the filesystem.
+// /       StopFS shuts down the log associated with the filesystem.
 func (fs *Fs_t) StopFS() {
 	fs.fslog.StopLog()
 }
 
-// / Fs_size returns the number of free inodes and blocks.
+// /       Fs_size returns the number of free inodes and blocks.
 func (fs *Fs_t) Fs_size() (uint, uint) {
 	return fs.ialloc.alloc.nfreebits, fs.balloc.alloc.nfreebits
 }
 
-// / IrefRoot increments the reference count on the root inode.
+// /       IrefRoot increments the reference count on the root inode.
 func (fs *Fs_t) IrefRoot() *imemnode_t {
 	r := fs.root
 	r.Refup("IrefRoot")
 	return r
 }
 
-// / MkRootCwd constructs a cwd that refers to the filesystem root.
+// /       MkRootCwd constructs a cwd that refers to the filesystem root.
 func (fs *Fs_t) MkRootCwd() *fd.Cwd_t {
 	f := &fd.Fd_t{Fops: &fsfops_t{priv: iroot, fs: fs, count: 0}}
 	cwd := fd.MkRootCwd(f)
 	return cwd
 }
 
-// / Unpin releases a pinned physical address from the buffer cache.
+// /       Unpin releases a pinned physical address from the buffer cache.
 func (fs *Fs_t) Unpin(pa mem.Pa_t) {
 	fs.bcache.unpin(pa)
 }
 
-// / Fs_op_link performs the actual filesystem link operation and returns any
-// / inodes that must be freed by the caller.
+// /       Fs_op_link performs the actual filesystem link operation and returns any
+// /       inodes that must be freed by the caller.
 func (fs *Fs_t) Fs_op_link(old ustr.Ustr, new ustr.Ustr, cwd *fd.Cwd_t) ([]*imemnode_t, defs.Err_t) {
 	opid := fs.fslog.Op_begin("Fs_link")
 	defer fs.fslog.Op_end(opid)
@@ -203,7 +203,7 @@ undo:
 	return deads, err
 }
 
-// / Fs_link links an existing file at a new path.
+// /       Fs_link links an existing file at a new path.
 func (fs *Fs_t) Fs_link(old ustr.Ustr, new ustr.Ustr, cwd *fd.Cwd_t) defs.Err_t {
 	deads, err := fs.Fs_op_link(old, new, cwd)
 	for _, dead := range deads {
@@ -212,7 +212,7 @@ func (fs *Fs_t) Fs_link(old ustr.Ustr, new ustr.Ustr, cwd *fd.Cwd_t) defs.Err_t 
 	return err
 }
 
-// / Fs_op_unlink performs the unlink operation and returns a possibly dead inode.
+// /       Fs_op_unlink performs the unlink operation and returns a possibly dead inode.
 func (fs *Fs_t) Fs_op_unlink(paths ustr.Ustr, cwd *fd.Cwd_t, wantdir bool) (*imemnode_t, defs.Err_t) {
 	opid := fs.fslog.Op_begin("fs_unlink")
 	defer fs.fslog.Op_end(opid)
@@ -293,7 +293,7 @@ func (fs *Fs_t) Fs_op_unlink(paths ustr.Ustr, cwd *fd.Cwd_t, wantdir bool) (*ime
 	return dead, 0
 }
 
-// / Fs_unlink removes a path and frees resources associated with the inode.
+// /       Fs_unlink removes a path and frees resources associated with the inode.
 func (fs *Fs_t) Fs_unlink(paths ustr.Ustr, cwd *fd.Cwd_t, wantdir bool) defs.Err_t {
 	dead, err := fs.Fs_op_unlink(paths, cwd, wantdir)
 	if dead != nil {
@@ -307,8 +307,8 @@ var _renamelock = sync.Mutex{}
 
 // first return value is inodes to refdown, second return is inode which needs
 // to be freed...
-// / Fs_op_rename renames a path to a new location and returns inodes that
-// / require cleanup by the caller.
+// /       Fs_op_rename renames a path to a new location and returns inodes that
+// /       require cleanup by the caller.
 func (fs *Fs_t) Fs_op_rename(oldp, newp ustr.Ustr, cwd *fd.Cwd_t) ([]*imemnode_t, *imemnode_t, defs.Err_t) {
 	odirs, ofn := bpath.Sdirname(oldp)
 	ndirs, nfn := bpath.Sdirname(newp)
@@ -518,7 +518,7 @@ func (fs *Fs_t) Fs_op_rename(oldp, newp ustr.Ustr, cwd *fd.Cwd_t) ([]*imemnode_t
 	return refs, nil, 0
 }
 
-// / Fs_rename renames a file or directory.
+// /       Fs_rename renames a file or directory.
 func (fs *Fs_t) Fs_rename(oldp, newp ustr.Ustr, cwd *fd.Cwd_t) defs.Err_t {
 	refs, dead, err := fs.Fs_op_rename(oldp, newp, cwd)
 	for _, r := range refs {
@@ -857,7 +857,7 @@ func (fo *fsfops_t) Shutdown(read, write bool) defs.Err_t {
 	return -defs.ENOTSOCK
 }
 
-// / Devfops_t identifies a special device handled by the filesystem.
+// /       Devfops_t identifies a special device handled by the filesystem.
 type Devfops_t struct {
 	Maj int
 	Min int
@@ -892,13 +892,13 @@ func stat_read(ub fdops.Userio_i, offset int) (int, defs.Err_t) {
 	return ret, 0
 }
 
-// / Perfrips_t holds profiling information about specific PC addresses.
+// /       Perfrips_t holds profiling information about specific PC addresses.
 type Perfrips_t struct {
 	Rips  []uintptr
 	Times []int
 }
 
-// / Init fills the Perfrips_t with profiling data.
+// /       Init fills the Perfrips_t with profiling data.
 func (pr *Perfrips_t) Init(m map[uintptr]int) {
 	l := len(m)
 	pr.Rips = make([]uintptr, l)
@@ -911,22 +911,22 @@ func (pr *Perfrips_t) Init(m map[uintptr]int) {
 	}
 }
 
-// / Reset clears all recorded profiling information.
+// /       Reset clears all recorded profiling information.
 func (pr *Perfrips_t) Reset() {
 	pr.Rips, pr.Times = nil, nil
 }
 
-// / Len returns the number of recorded addresses.
+// /       Len returns the number of recorded addresses.
 func (pr *Perfrips_t) Len() int {
 	return len(pr.Rips)
 }
 
-// / Less implements sort.Interface for ordering.
+// /       Less implements sort.Interface for ordering.
 func (pr *Perfrips_t) Less(i, j int) bool {
 	return pr.Times[i] < pr.Times[j]
 }
 
-// / Swap implements sort.Interface for sorting.
+// /       Swap implements sort.Interface for sorting.
 func (pr *Perfrips_t) Swap(i, j int) {
 	pr.Rips[i], pr.Rips[j] = pr.Rips[j], pr.Rips[i]
 	pr.Times[i], pr.Times[j] = pr.Times[j], pr.Times[i]
@@ -1255,7 +1255,7 @@ func (raw *rawdfops_t) Shutdown(read, write bool) defs.Err_t {
 	return -defs.ENOTSOCK
 }
 
-// / Fs_mkdir creates a new directory at the provided path.
+// /       Fs_mkdir creates a new directory at the provided path.
 func (fs *Fs_t) Fs_mkdir(paths ustr.Ustr, mode int, cwd *fd.Cwd_t) defs.Err_t {
 	refs, dead, err := fs.Fs_op_mkdir(paths, mode, cwd)
 	for _, ref := range refs {
@@ -1270,8 +1270,8 @@ func (fs *Fs_t) Fs_mkdir(paths ustr.Ustr, mode int, cwd *fd.Cwd_t) defs.Err_t {
 }
 
 // returns refs, dead, and error...
-// / Fs_op_mkdir creates a directory and returns references that need dropping
-// / by the caller.
+// /       Fs_op_mkdir creates a directory and returns references that need dropping
+// /       by the caller.
 func (fs *Fs_t) Fs_op_mkdir(paths ustr.Ustr, mode int, cwd *fd.Cwd_t) ([]*imemnode_t, *imemnode_t, defs.Err_t) {
 	opid := fs.fslog.Op_begin("fs_mkdir")
 	defer fs.fslog.Op_end(opid)
@@ -1325,14 +1325,14 @@ outunlink:
 }
 
 // a type to represent on-disk files
-// / Fsfile_t describes a file opened on disk.
+// /       Fsfile_t describes a file opened on disk.
 type Fsfile_t struct {
 	Inum  defs.Inum_t
 	Major int
 	Minor int
 }
 
-// / Fs_open_inner opens a file and returns a descriptor describing it.
+// /       Fs_open_inner opens a file and returns a descriptor describing it.
 func (fs *Fs_t) Fs_open_inner(paths ustr.Ustr, flags defs.Fdopt_t, mode int, cwd *fd.Cwd_t, major, minor int) (Fsfile_t, defs.Err_t) {
 	ret, dead, err := fs._fs_open_inner(paths, flags, mode, cwd, major, minor)
 	if dead != nil {
@@ -1443,7 +1443,7 @@ func (fs *Fs_t) _fs_open_inner(paths ustr.Ustr, flags defs.Fdopt_t, mode int, cw
 	return ret, nil, 0
 }
 
-// / Makefake returns a dummy file descriptor for testing.
+// /       Makefake returns a dummy file descriptor for testing.
 func (fs *Fs_t) Makefake() *fd.Fd_t {
 	return nil
 	//ret := &fd.Fd_t{}
@@ -1465,7 +1465,7 @@ func (fs *Fs_t) Makefake() *fd.Fd_t {
 // socket files cannot be open(2)'ed (must use connect(2)/sendto(2) etc.)
 var _denyopen = map[int]bool{defs.D_SUD: true, defs.D_SUS: true}
 
-// / Fs_open opens a path and returns a new file descriptor.
+// /       Fs_open opens a path and returns a new file descriptor.
 func (fs *Fs_t) Fs_open(paths ustr.Ustr, flags defs.Fdopt_t, mode int, cwd *fd.Cwd_t, major, minor int) (*fd.Fd_t, defs.Err_t) {
 	fs.istats.Nopen.Inc()
 	fsf, err := fs.Fs_open_inner(paths, flags, mode, cwd, major, minor)
@@ -1509,7 +1509,7 @@ func (fs *Fs_t) Fs_open(paths ustr.Ustr, flags defs.Fdopt_t, mode int, cwd *fd.C
 	return ret, 0
 }
 
-// / Fs_close closes the file represented by the given inode number.
+// /       Fs_close closes the file represented by the given inode number.
 func (fs *Fs_t) Fs_close(priv defs.Inum_t) defs.Err_t {
 	opid := fs.fslog.Op_begin("Fs_close")
 
@@ -1532,7 +1532,7 @@ func (fs *Fs_t) Fs_close(priv defs.Inum_t) defs.Err_t {
 	return 0
 }
 
-// / Fs_stat retrieves file information for the provided path.
+// /       Fs_stat retrieves file information for the provided path.
 func (fs *Fs_t) Fs_stat(path ustr.Ustr, st *stat.Stat_t, cwd *fd.Cwd_t) defs.Err_t {
 	opid := opid_t(0)
 
@@ -1556,7 +1556,7 @@ func (fs *Fs_t) Fs_stat(path ustr.Ustr, st *stat.Stat_t, cwd *fd.Cwd_t) defs.Err
 
 // Sync the file system to disk. XXX If Biscuit supported fsync, we could be
 // smarter and flush only the dirty blocks of particular inode.
-// / Fs_sync flushes all filesystem metadata to stable storage.
+// /       Fs_sync flushes all filesystem metadata to stable storage.
 func (fs *Fs_t) Fs_sync() defs.Err_t {
 	if !fs.diskfs {
 		return 0
@@ -1566,7 +1566,7 @@ func (fs *Fs_t) Fs_sync() defs.Err_t {
 	return 0
 }
 
-// / Fs_syncapply flushes metadata and applies the log immediately.
+// /       Fs_syncapply flushes metadata and applies the log immediately.
 func (fs *Fs_t) Fs_syncapply() defs.Err_t {
 	if !fs.diskfs {
 		return 0
@@ -1681,7 +1681,7 @@ func (fs *Fs_t) fs_namei_locked(opid opid_t, paths ustr.Ustr, cwd *fd.Cwd_t, s s
 	return fs._fs_namei_locked(opid, paths, cwd)
 }
 
-// / Fs_evict drops half of the cache entries and returns the new sizes.
+// /       Fs_evict drops half of the cache entries and returns the new sizes.
 func (fs *Fs_t) Fs_evict() (int, int) {
 	if !fs.diskfs {
 		panic("no evict")
@@ -1692,7 +1692,7 @@ func (fs *Fs_t) Fs_evict() (int, int) {
 	return fs.Sizes()
 }
 
-// / Fs_statistics dumps collected file system statistics and resets them.
+// /       Fs_statistics dumps collected file system statistics and resets them.
 func (fs *Fs_t) Fs_statistics() string {
 	s := fs.istats.Stats()
 	if fs.diskfs {

--- a/biscuit/src/fs/inode.go
+++ b/biscuit/src/fs/inode.go
@@ -17,7 +17,7 @@ import "stats"
 import "ustr"
 import "util"
 
-// / inode_stats_t collects statistics about inode operations.
+// /       inode_stats_t collects statistics about inode operations.
 type inode_stats_t struct {
 	Nopen       stats.Counter_t
 	Nnamei      stats.Counter_t
@@ -48,14 +48,14 @@ type inode_stats_t struct {
 	Ciupdate    stats.Cycles_t
 }
 
-// / Stats resets and returns the accumulated inode statistics.
+// /       Stats resets and returns the accumulated inode statistics.
 func (is *inode_stats_t) Stats() string {
 	s := "inode" + stats.Stats2String(*is)
 	*is = inode_stats_t{}
 	return s
 }
 
-// / Inode_t provides indexed access to the on-disk inode structure.
+// /       Inode_t provides indexed access to the on-disk inode structure.
 type Inode_t struct {
 	Iblk *Bdev_block_t
 	Ioff int
@@ -127,7 +127,7 @@ func (ind *Inode_t) addr(i int) int {
 	return fieldr(ind.Iblk.Data, ifield(ind.Ioff, addroff+i))
 }
 
-// / W_itype updates the inode's type field.
+// /       W_itype updates the inode's type field.
 func (ind *Inode_t) W_itype(n int) {
 	if n < I_FIRST || n > I_LAST {
 		panic("weird inode type")
@@ -135,12 +135,12 @@ func (ind *Inode_t) W_itype(n int) {
 	fieldw(ind.Iblk.Data, ifield(ind.Ioff, 0), n)
 }
 
-// / W_linkcount writes the link count.
+// /       W_linkcount writes the link count.
 func (ind *Inode_t) W_linkcount(n int) {
 	fieldw(ind.Iblk.Data, ifield(ind.Ioff, 1), n)
 }
 
-// / W_size records the inode's size in bytes.
+// /       W_size records the inode's size in bytes.
 func (ind *Inode_t) W_size(n int) {
 	fieldw(ind.Iblk.Data, ifield(ind.Ioff, 2), n)
 }
@@ -163,7 +163,7 @@ func (ind *Inode_t) w_dindirect(blk int) {
 	fieldw(ind.Iblk.Data, ifield(ind.Ioff, 6), blk)
 }
 
-// / W_addr sets the i'th direct block address.
+// /       W_addr sets the i'th direct block address.
 func (ind *Inode_t) W_addr(i int, blk int) {
 	if i < 0 || i > NIADDRS {
 		panic("bad inode block index")
@@ -208,16 +208,19 @@ type imemnode_t struct {
 	}
 }
 
+// /      String returns a textual representation of the inode for debugging.
 func (idm *imemnode_t) String() string {
 	s := ""
 	s += fmt.Sprintf("[inum %d type %d]\n", idm.inum, idm.itype)
 	return s
 }
 
+// /      Refup increments the reference count on the inode.
 func (imem *imemnode_t) Refup(s string) (uint32, bool) {
 	return imem.ref.Up()
 }
 
+// /      Refdown decrements the reference count and reports when the inode is free.
 func (imem *imemnode_t) Refdown(s string) bool {
 	v := imem.ref.Down()
 	if v == 0 && imem.links == 0 { // remove unlinked inodes from cache
@@ -246,6 +249,7 @@ func (idm *imemnode_t) evictDcache() {
 	idm._derelease()
 }
 
+// /      EvictFromCache removes cached directory entries for an unused inode.
 // The cache wants to evict this inode because it hasn't been used recently, but
 // its links maybe non-zero, so it could be in use.
 func (idm *imemnode_t) EvictFromCache() {
@@ -254,10 +258,12 @@ func (idm *imemnode_t) EvictFromCache() {
 	idm.iunlock("Evict")
 }
 
+// /      EvictDone cleans up state after EvictFromCache completed.
 func (idm *imemnode_t) EvictDone() {
 	// nothing to do anymore: Evict() already deleted idm's directory cache
 }
 
+// /      Free releases all resources associated with the inode.
 func (idm *imemnode_t) Free() {
 	// no need to lock...
 	if idm.links != 0 {

--- a/biscuit/src/fs/super.go
+++ b/biscuit/src/fs/super.go
@@ -2,89 +2,89 @@ package fs
 
 import "mem"
 
-// / Superblock_t represents the on-disk super block of a filesystem.
+// /       Superblock_t represents the on-disk super block of a filesystem.
 type Superblock_t struct {
 	Data *mem.Bytepg_t
 }
 
-// / Loglen returns the length of the on-disk log in blocks.
+// /       Loglen returns the length of the on-disk log in blocks.
 func (sb *Superblock_t) Loglen() int {
 	return fieldr(sb.Data, 0)
 }
 
-// / Iorphanblock returns the starting block of the orphan inode map.
+// /       Iorphanblock returns the starting block of the orphan inode map.
 func (sb *Superblock_t) Iorphanblock() int {
 	return fieldr(sb.Data, 1)
 }
 
-// / Iorphanlen returns the length of the orphan inode map.
+// /       Iorphanlen returns the length of the orphan inode map.
 func (sb *Superblock_t) Iorphanlen() int {
 	return fieldr(sb.Data, 2)
 }
 
-// / Imaplen returns the length of the inode bitmap.
+// /       Imaplen returns the length of the inode bitmap.
 func (sb *Superblock_t) Imaplen() int {
 	return fieldr(sb.Data, 3)
 }
 
-// / Freeblock gives the starting block of the free block map.
+// /       Freeblock gives the starting block of the free block map.
 func (sb *Superblock_t) Freeblock() int {
 	return fieldr(sb.Data, 4)
 }
 
-// / Freeblocklen returns the length of the free block map.
+// /       Freeblocklen returns the length of the free block map.
 func (sb *Superblock_t) Freeblocklen() int {
 	return fieldr(sb.Data, 5)
 }
 
-// / Inodelen reports the number of blocks containing inodes.
+// /       Inodelen reports the number of blocks containing inodes.
 func (sb *Superblock_t) Inodelen() int {
 	return fieldr(sb.Data, 6)
 }
 
-// / Lastblock returns the address of the last block on the device.
+// /       Lastblock returns the address of the last block on the device.
 func (sb *Superblock_t) Lastblock() int {
 	return fieldr(sb.Data, 7)
 }
 
 // writing
 
-// / SetLoglen updates the log length field.
+// /       SetLoglen updates the log length field.
 func (sb *Superblock_t) SetLoglen(ll int) {
 	fieldw(sb.Data, 0, ll)
 }
 
-// / SetIorphanblock records the starting block of the orphan map.
+// /       SetIorphanblock records the starting block of the orphan map.
 func (sb *Superblock_t) SetIorphanblock(n int) {
 	fieldw(sb.Data, 1, n)
 }
 
-// / SetIorphanlen writes the length of the orphan map.
+// /       SetIorphanlen writes the length of the orphan map.
 func (sb *Superblock_t) SetIorphanlen(n int) {
 	fieldw(sb.Data, 2, n)
 }
 
-// / SetImaplen writes the length of the inode bitmap.
+// /       SetImaplen writes the length of the inode bitmap.
 func (sb *Superblock_t) SetImaplen(n int) {
 	fieldw(sb.Data, 3, n)
 }
 
-// / SetFreeblock stores the start block of the free block bitmap.
+// /       SetFreeblock stores the start block of the free block bitmap.
 func (sb *Superblock_t) SetFreeblock(n int) {
 	fieldw(sb.Data, 4, n)
 }
 
-// / SetFreeblocklen writes the free block bitmap length.
+// /       SetFreeblocklen writes the free block bitmap length.
 func (sb *Superblock_t) SetFreeblocklen(n int) {
 	fieldw(sb.Data, 5, n)
 }
 
-// / SetInodelen writes the number of inode blocks.
+// /       SetInodelen writes the number of inode blocks.
 func (sb *Superblock_t) SetInodelen(n int) {
 	fieldw(sb.Data, 6, n)
 }
 
-// / SetLastblock stores the address of the last block on the disk.
+// /       SetLastblock stores the address of the last block on the disk.
 func (sb *Superblock_t) SetLastblock(n int) {
 	fieldw(sb.Data, 7, n)
 }

--- a/biscuit/src/hashtable/hashtable.go
+++ b/biscuit/src/hashtable/hashtable.go
@@ -61,18 +61,18 @@ func (b *bucket_t) iter(f func(interface{}, interface{}) bool) bool {
 	return false
 }
 
-// /   Hashtable_t represents a basic hash table mapping keys to values.
-// /   It is protected internally by bucket locks.
+// /         Hashtable_t represents a basic hash table mapping keys to values.
+// /         It is protected internally by bucket locks.
 type Hashtable_t struct {
 	table    []*bucket_t
 	capacity int
 	maxchain int
 }
 
-// /   MkHash allocates a new Hashtable_t with the given size.
+// /         MkHash allocates a new Hashtable_t with the given size.
 // /
-// /   \param size number of buckets to allocate
-// /   \return pointer to an initialized Hashtable_t.
+// /         \param size number of buckets to allocate
+// /         \return pointer to an initialized Hashtable_t.
 func MkHash(size int) *Hashtable_t {
 	ht := &Hashtable_t{}
 	ht.capacity = size
@@ -84,9 +84,9 @@ func MkHash(size int) *Hashtable_t {
 	return ht
 }
 
-// /   String returns a formatted representation of the table contents.
+// /         String returns a formatted representation of the table contents.
 // /
-// /   \return string description of bucket chains.
+// /         \return string description of bucket chains.
 func (ht *Hashtable_t) String() string {
 	s := ""
 	for i, b := range ht.table {
@@ -101,9 +101,9 @@ func (ht *Hashtable_t) String() string {
 	return s
 }
 
-// /   Size returns the total number of elements stored in the table.
+// /         Size returns the total number of elements stored in the table.
 // /
-// /   \return element count.
+// /         \return element count.
 func (ht *Hashtable_t) Size() int {
 	n := 0
 	for _, b := range ht.table {
@@ -112,15 +112,15 @@ func (ht *Hashtable_t) Size() int {
 	return n
 }
 
-// /   Pair_t represents a key/value tuple returned by Elems.
+// /         Pair_t represents a key/value tuple returned by Elems.
 type Pair_t struct {
 	Key   interface{}
 	Value interface{}
 }
 
-// /   Elems returns all key/value pairs currently stored.
+// /         Elems returns all key/value pairs currently stored.
 // /
-// /   \return slice of Pair_t containing each element.
+// /         \return slice of Pair_t containing each element.
 func (ht *Hashtable_t) Elems() []Pair_t {
 	p := make([]Pair_t, 0)
 	for _, b := range ht.table {
@@ -132,10 +132,10 @@ func (ht *Hashtable_t) Elems() []Pair_t {
 	return p
 }
 
-// /   Get looks up the provided key and returns its value.
+// /         Get looks up the provided key and returns its value.
 // /
-// /   \param key value to search for
-// /   \return stored value and true when found.
+// /         \param key value to search for
+// /         \return stored value and true when found.
 func (ht *Hashtable_t) Get(key interface{}) (interface{}, bool) {
 	kh := khash(key)
 	b := ht.table[ht.hash(kh)]
@@ -156,11 +156,11 @@ func (ht *Hashtable_t) Get(key interface{}) (interface{}, bool) {
 	return nil, false
 }
 
-// /   GetRLock performs Get while holding a read lock.
-// /   Used only for performance comparisons.
+// /         GetRLock performs Get while holding a read lock.
+// /         Used only for performance comparisons.
 // /
-// /   \param key value to search for
-// /   \return stored value and true when found.
+// /         \param key value to search for
+// /         \return stored value and true when found.
 func (ht *Hashtable_t) GetRLock(key interface{}) (interface{}, bool) {
 	kh := khash(key)
 	b := ht.table[ht.hash(kh)]
@@ -184,11 +184,11 @@ func (ht *Hashtable_t) GetRLock(key interface{}) (interface{}, bool) {
 	return nil, false
 }
 
-// /   Set inserts a key/value pair and returns false if the key already existed.
+// /         Set inserts a key/value pair and returns false if the key already existed.
 // /
-// /   \param key identifier
-// /   \param value data to store
-// /   \return previous value and true when inserted.
+// /         \param key identifier
+// /         \param value data to store
+// /         \return previous value and true when inserted.
 func (ht *Hashtable_t) Set(key interface{}, value interface{}) (interface{}, bool) {
 	kh := khash(key)
 	b := ht.table[ht.hash(kh)]
@@ -220,9 +220,9 @@ func (ht *Hashtable_t) Set(key interface{}, value interface{}) (interface{}, boo
 	return value, true
 }
 
-// /   Del removes a key from the table.
+// /         Del removes a key from the table.
 // /
-// /   \param key identifier to delete
+// /         \param key identifier to delete
 func (ht *Hashtable_t) Del(key interface{}) {
 	kh := khash(key)
 	b := ht.table[ht.hash(kh)]
@@ -253,11 +253,11 @@ func (ht *Hashtable_t) Del(key interface{}) {
 	panic("del of non-existing key")
 }
 
-// /   Iter applies f to each key/value pair.
+// /         Iter applies f to each key/value pair.
 // /
-// /   Iteration stops when f returns true.
-// /   \param f visitor function
-// /   \return true if f returned true for any element.
+// /         Iteration stops when f returns true.
+// /         \param f visitor function
+// /         \return true if f returned true for any element.
 func (ht *Hashtable_t) Iter(f func(interface{}, interface{}) bool) bool {
 	for _, b := range ht.table {
 		if b.iter(f) {

--- a/biscuit/src/hashtable/hashtable_test.go
+++ b/biscuit/src/hashtable/hashtable_test.go
@@ -25,7 +25,7 @@ func fill(t *testing.T, ht hashtable_i, n int) {
 
 const SZ = 10
 
-// / TestSimple exercises basic hashtable operations.
+// /       TestSimple exercises basic hashtable operations.
 func TestSimple(t *testing.T) {
 	ht := MkHash(SZ)
 
@@ -101,7 +101,7 @@ func reader(t *testing.T, ht hashtable_i, done *int32) int {
 	return n
 }
 
-// / TestManyWriter spawns writers concurrently to stress the table.
+// /       TestManyWriter spawns writers concurrently to stress the table.
 func TestManyWriter(t *testing.T) {
 	ht := MkHash(SZ)
 
@@ -150,13 +150,13 @@ func doTestManyReader(ht hashtable_i, t *testing.T) {
 	fmt.Printf("TestManyReader:  %d/s\n", total)
 }
 
-// / TestManyReader runs multiple readers in parallel.
+// /       TestManyReader runs multiple readers in parallel.
 func TestManyReader(t *testing.T) {
 	ht := MkHash(SZ)
 	doTestManyReader(ht, t)
 }
 
-// / TestManyReaderStd validates the standard-map implementation.
+// /       TestManyReaderStd validates the standard-map implementation.
 func TestManyReaderStd(t *testing.T) {
 	ht := MkHashString(SZ)
 	doTestManyReader(ht, t)
@@ -188,19 +188,19 @@ func doTestManyReaderOneWriter(ht hashtable_i, t *testing.T) {
 	fmt.Printf("TestManyReaderOneWriter: reads %d/s writes %d/s\n", nreads, nwrites)
 }
 
-// / TestManyReaderOneWriter mixes readers with a single writer.
+// /       TestManyReaderOneWriter mixes readers with a single writer.
 func TestManyReaderOneWriter(t *testing.T) {
 	ht := MkHash(SZ)
 	doTestManyReaderOneWriter(ht, t)
 }
 
-// / TestManyReaderOneWriterStd tests the map-based table with readers and one writer.
+// /       TestManyReaderOneWriterStd tests the map-based table with readers and one writer.
 func TestManyReaderOneWriterStd(t *testing.T) {
 	ht := MkHashString(SZ)
 	doTestManyReaderOneWriter(ht, t)
 }
 
-// / TestManyReaderOneWriterSyncMap benchmarks sync.Map with readers and writer.
+// /       TestManyReaderOneWriterSyncMap benchmarks sync.Map with readers and writer.
 func TestManyReaderOneWriterSyncMap(t *testing.T) {
 	ht := MkSyncMap(SZ)
 	doTestManyReaderOneWriter(ht, t)
@@ -208,13 +208,13 @@ func TestManyReaderOneWriterSyncMap(t *testing.T) {
 
 // For performance comparisons
 
-// / hashtablestring_t is a simple map based implementation used for comparison.
+// /       hashtablestring_t is a simple map based implementation used for comparison.
 type hashtablestring_t struct {
 	sync.RWMutex
 	table map[string]int
 }
 
-// / MkHashString creates a hashtable backed by a Go map.
+// /       MkHashString creates a hashtable backed by a Go map.
 func MkHashString(size int) *hashtablestring_t {
 	ht := &hashtablestring_t{}
 	ht.table = make(map[string]int, size)
@@ -248,12 +248,12 @@ func (ht *hashtablestring_t) Del(key interface{}) {
 	delete(ht.table, k)
 }
 
-// / SyncMap_t wraps sync.Map for performance comparison.
+// /       SyncMap_t wraps sync.Map for performance comparison.
 type SyncMap_t struct {
 	m sync.Map
 }
 
-// / MkSyncMap instantiates a SyncMap_t.
+// /       MkSyncMap instantiates a SyncMap_t.
 func MkSyncMap(size int) *SyncMap_t {
 	ht := &SyncMap_t{}
 	return ht

--- a/biscuit/src/inet/inet.go
+++ b/biscuit/src/inet/inet.go
@@ -5,16 +5,16 @@ import "unsafe"
 import "util"
 import "time"
 
-// / Ip4_t represents an IPv4 address in host byte order.
+// /       Ip4_t represents an IPv4 address in host byte order.
 type Ip4_t uint32
 
-// / Be16 is a 16-bit big-endian value.
+// /       Be16 is a 16-bit big-endian value.
 type Be16 uint16
 
-// / Be32 is a 32-bit big-endian value.
+// /       Be32 is a 32-bit big-endian value.
 type Be32 uint32
 
-// / Ip2sl converts an IPv4 address to network byte order.
+// /       Ip2sl converts an IPv4 address to network byte order.
 func Ip2sl(sl []uint8, ip Ip4_t) {
 	sl[0] = uint8(ip >> 24)
 	sl[1] = uint8(ip >> 16)
@@ -22,7 +22,7 @@ func Ip2sl(sl []uint8, ip Ip4_t) {
 	sl[3] = uint8(ip >> 0)
 }
 
-// / Sl2ip converts a 4 byte slice to an IPv4 address.
+// /       Sl2ip converts a 4 byte slice to an IPv4 address.
 func Sl2ip(sl []uint8) Ip4_t {
 	ret := Ip4_t(sl[0]) << 24
 	ret |= Ip4_t(sl[1]) << 16
@@ -31,24 +31,24 @@ func Sl2ip(sl []uint8) Ip4_t {
 	return ret
 }
 
-// / Ip2str formats an IPv4 address in dotted notation.
+// /       Ip2str formats an IPv4 address in dotted notation.
 func Ip2str(ip Ip4_t) string {
 	return fmt.Sprintf("%d.%d.%d.%d", ip>>24, uint8(ip>>16),
 		uint8(ip>>8), uint8(ip))
 }
 
-// / Mac2str formats a MAC address as a string.
+// /       Mac2str formats a MAC address as a string.
 func Mac2str(m []uint8) string {
 	return fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x", m[0], m[1], m[2],
 		m[3], m[4], m[5])
 }
 
-// / Htons converts a 16-bit value to network byte order.
+// /       Htons converts a 16-bit value to network byte order.
 func Htons(v uint16) Be16 {
 	return Be16(v>>8 | (v&0xff)<<8)
 }
 
-// / Htonl converts a 32-bit value to network byte order.
+// /       Htonl converts a 32-bit value to network byte order.
 func Htonl(v uint32) Be32 {
 	r := (v & 0x000000ff) << 24
 	r |= (v & 0x0000ff00) << 8
@@ -57,12 +57,12 @@ func Htonl(v uint32) Be32 {
 	return Be32(r)
 }
 
-// / Ntohs converts a 16-bit big-endian value to host order.
+// /       Ntohs converts a 16-bit big-endian value to host order.
 func Ntohs(v Be16) uint16 {
 	return uint16(v>>8 | (v&0xff)<<8)
 }
 
-// / Ntohl converts a 32-bit big-endian value to host order.
+// /       Ntohl converts a 32-bit big-endian value to host order.
 func Ntohl(v Be32) uint32 {
 	r := (v & 0x000000ff) << 24
 	r |= (v & 0x0000ff00) << 8
@@ -76,11 +76,11 @@ const ARPLEN = int(unsafe.Sizeof(Arpv4_t{}))
 // always big-endian
 const macsz int = 6
 
-// / Mac_t represents a 6-byte hardware address.
+// /       Mac_t represents a 6-byte hardware address.
 type Mac_t [macsz]uint8
 
 // arpv4_t gets padded if tpa is a uint32 instead of a byte array...
-// / Arpv4_t represents an ARP packet for IPv4.
+// /       Arpv4_t represents an ARP packet for IPv4.
 type Arpv4_t struct {
 	Etherhdr_t
 	htype Be16
@@ -108,7 +108,7 @@ func (ar *Arpv4_t) _init(smac *Mac_t) {
 	copy(ar.smac[:], smac[:])
 }
 
-// / Init_req prepares an ARP request packet.
+// /       Init_req prepares an ARP request packet.
 func (ar *Arpv4_t) Init_req(smac *Mac_t, sip, qip Ip4_t) {
 	ar._init(smac)
 	req := Htons(1)
@@ -123,7 +123,7 @@ func (ar *Arpv4_t) Init_req(smac *Mac_t, sip, qip Ip4_t) {
 	}
 }
 
-// / Init_reply prepares an ARP reply packet.
+// /       Init_reply prepares an ARP reply packet.
 func (ar *Arpv4_t) Init_reply(smac, dmac *Mac_t, sip, dip Ip4_t) {
 	ar._init(smac)
 	reply := Htons(2)
@@ -135,7 +135,7 @@ func (ar *Arpv4_t) Init_reply(smac, dmac *Mac_t, sip, dip Ip4_t) {
 	copy(ar.dmac[:], dmac[:])
 }
 
-// / Bytes returns the ARP packet as a byte slice.
+// /       Bytes returns the ARP packet as a byte slice.
 func (ar *Arpv4_t) Bytes() []uint8 {
 	return (*[ARPLEN]uint8)(unsafe.Pointer(ar))[:]
 }
@@ -143,7 +143,7 @@ func (ar *Arpv4_t) Bytes() []uint8 {
 const IP4LEN = int(unsafe.Sizeof(Ip4hdr_t{}))
 
 // no options
-// / Ip4hdr_t is a minimal IPv4 header without options.
+// /       Ip4hdr_t is a minimal IPv4 header without options.
 type Ip4hdr_t struct {
 	Vers_hdr uint8
 	Dscp     uint8
@@ -157,7 +157,7 @@ type Ip4hdr_t struct {
 	Dip      [4]uint8
 }
 
-// / Sl2iphdr parses an IPv4 header from the front of buf.
+// /       Sl2iphdr parses an IPv4 header from the front of buf.
 func Sl2iphdr(buf []uint8) (*Ip4hdr_t, []uint8, bool) {
 	if len(buf) < IP4LEN {
 		return nil, nil, false
@@ -182,31 +182,31 @@ func (i4 *Ip4hdr_t) _init(l4len int, sip, dip Ip4_t, proto uint8) {
 	Ip2sl(i4.Dip[:], dip)
 }
 
-// / Init_icmp populates the header fields for an ICMP packet.
+// /       Init_icmp populates the header fields for an ICMP packet.
 func (i4 *Ip4hdr_t) Init_icmp(icmplen int, sip, dip Ip4_t) {
 	icmp := uint8(0x01)
 	i4._init(icmplen, sip, dip, icmp)
 }
 
-// / Init_tcp populates the header fields for a TCP packet.
+// /       Init_tcp populates the header fields for a TCP packet.
 func (i4 *Ip4hdr_t) Init_tcp(tcplen int, sip, dip Ip4_t) {
 	tcp := uint8(0x06)
 	i4._init(tcplen, sip, dip, tcp)
 }
 
-// / Bytes returns the header as a byte slice.
+// /       Bytes returns the header as a byte slice.
 func (i4 *Ip4hdr_t) Bytes() []uint8 {
 	return (*[IP4LEN]uint8)(unsafe.Pointer(i4))[:]
 }
 
-// / Hdrlen returns the size of the header in bytes.
+// /       Hdrlen returns the size of the header in bytes.
 func (i4 *Ip4hdr_t) Hdrlen() int {
 	return IP4LEN
 }
 
 const ETHERLEN = int(unsafe.Sizeof(Etherhdr_t{}))
 
-// / Etherhdr_t is an Ethernet header.
+// /       Etherhdr_t is an Ethernet header.
 type Etherhdr_t struct {
 	dmac  Mac_t
 	smac  Mac_t
@@ -222,18 +222,18 @@ func (et *Etherhdr_t) _init(smac, dmac []uint8, etype uint16) {
 	et.etype = Htons(etype)
 }
 
-// / Init_ip4 initializes the header for an IPv4 packet.
+// /       Init_ip4 initializes the header for an IPv4 packet.
 func (et *Etherhdr_t) Init_ip4(smac, dmac []uint8) {
 	etype := uint16(0x0800)
 	et._init(smac, dmac, etype)
 }
 
-// / Bytes returns the Ethernet header as a byte slice.
+// /       Bytes returns the Ethernet header as a byte slice.
 func (e *Etherhdr_t) Bytes() []uint8 {
 	return (*[ETHERLEN]uint8)(unsafe.Pointer(e))[:]
 }
 
-// / Tcphdr_t represents a minimal TCP header.
+// /       Tcphdr_t represents a minimal TCP header.
 type Tcphdr_t struct {
 	Sport   Be16
 	Dport   Be16
@@ -258,14 +258,14 @@ func (t *Tcphdr_t) _init(sport, dport uint16, seq, ack uint32) {
 	t.Dataoff = 0x50
 }
 
-// / Init_syn initializes a SYN packet header.
+// /       Init_syn initializes a SYN packet header.
 func (t *Tcphdr_t) Init_syn(Sport, Dport uint16, seq uint32) {
 	t._init(Sport, Dport, seq, 0)
 	synf := uint8(1 << 1)
 	t.Flags |= synf
 }
 
-// / Init_synack initializes a SYN+ACK packet header.
+// /       Init_synack initializes a SYN+ACK packet header.
 func (t *Tcphdr_t) Init_synack(Sport, Dport uint16, seq, ack uint32) {
 	t._init(Sport, Dport, seq, ack)
 	synf := uint8(1 << 1)
@@ -273,21 +273,21 @@ func (t *Tcphdr_t) Init_synack(Sport, Dport uint16, seq, ack uint32) {
 	t.Flags |= synf | ackf
 }
 
-// / Init_ack initializes an ACK packet header.
+// /       Init_ack initializes an ACK packet header.
 func (t *Tcphdr_t) Init_ack(Sport, Dport uint16, seq, ack uint32) {
 	t._init(Sport, Dport, seq, ack)
 	ackf := uint8(1 << 4)
 	t.Flags |= ackf
 }
 
-// / Init_rst initializes a RST packet header.
+// /       Init_rst initializes a RST packet header.
 func (t *Tcphdr_t) Init_rst(Sport, Dport uint16, seq uint32) {
 	t._init(Sport, Dport, seq, 0)
 	rst := uint8(1 << 2)
 	t.Flags |= rst
 }
 
-// / Set_opt populates the TCP option fields and updates Dataoff.
+// /       Set_opt populates the TCP option fields and updates Dataoff.
 func (t *Tcphdr_t) Set_opt(opt []uint8, tsopt []uint8, tsecr uint32) {
 	if len(tsopt) < 10 {
 		panic("not enough room for timestamps")
@@ -302,47 +302,47 @@ func (t *Tcphdr_t) Set_opt(opt []uint8, tsopt []uint8, tsecr uint32) {
 	util.Writen(tsopt, 4, 6, int(Htonl(tsecr)))
 }
 
-// / Hdrlen returns the TCP header length in bytes.
+// /       Hdrlen returns the TCP header length in bytes.
 func (t *Tcphdr_t) Hdrlen() int {
 	return int(t.Dataoff>>4) * 4
 }
 
-// / Issyn reports whether the SYN flag is set.
+// /       Issyn reports whether the SYN flag is set.
 func (t *Tcphdr_t) Issyn() bool {
 	synf := uint8(1 << 1)
 	return t.Flags&synf != 0
 }
 
-// / Isack reports whether the ACK flag is set and returns the ack number.
+// /       Isack reports whether the ACK flag is set and returns the ack number.
 func (t *Tcphdr_t) Isack() (uint32, bool) {
 	ackf := uint8(1 << 4)
 	return Ntohl(t.Ack), t.Flags&ackf != 0
 }
 
-// / Isrst reports whether the RST flag is set.
+// /       Isrst reports whether the RST flag is set.
 func (t *Tcphdr_t) Isrst() bool {
 	rst := uint8(1 << 2)
 	return t.Flags&rst != 0
 }
 
-// / Isfin reports whether the FIN flag is set.
+// /       Isfin reports whether the FIN flag is set.
 func (t *Tcphdr_t) Isfin() bool {
 	fin := uint8(1 << 0)
 	return t.Flags&fin != 0
 }
 
-// / Ispush reports whether the PSH flag is set.
+// /       Ispush reports whether the PSH flag is set.
 func (t *Tcphdr_t) Ispush() bool {
 	pu := uint8(1 << 3)
 	return t.Flags&pu != 0
 }
 
-// / Bytes returns the TCP header as a byte slice.
+// /       Bytes returns the TCP header as a byte slice.
 func (t *Tcphdr_t) Bytes() []uint8 {
 	return (*[TCPLEN]uint8)(unsafe.Pointer(t))[:]
 }
 
-// / Dump prints a human readable representation of the header.
+// /       Dump prints a human readable representation of the header.
 func (t *Tcphdr_t) Dump(sip, dip Ip4_t, opt Tcpopt_t, dlen int) {
 	s := fmt.Sprintf("%s:%d -> %s:%d", Ip2str(sip), Ntohs(t.Sport),
 		Ip2str(dip), Ntohs(t.Dport))
@@ -378,7 +378,7 @@ func (t *Tcphdr_t) Dump(sip, dip Ip4_t, opt Tcpopt_t, dlen int) {
 	fmt.Printf("%s\n", s)
 }
 
-// / Tcpopt_t contains parsed TCP option values.
+// /       Tcpopt_t contains parsed TCP option values.
 type Tcpopt_t struct {
 	Wshift uint
 	Tsval  uint32
@@ -447,6 +447,7 @@ outer:
 	return ret
 }
 
+// /      Sl2tcphdr parses a TCP header and options from the front of buf.
 func Sl2tcphdr(buf []uint8) (*Tcphdr_t, Tcpopt_t, []uint8, bool) {
 	if len(buf) < TCPLEN {
 		var z Tcpopt_t
@@ -463,7 +464,7 @@ func Sl2tcphdr(buf []uint8) (*Tcphdr_t, Tcpopt_t, []uint8, bool) {
 	return p, opt, rest, true
 }
 
-// / Tcppkt_t bundles an Ethernet, IP and TCP header for convenience.
+// /       Tcppkt_t bundles an Ethernet, IP and TCP header for convenience.
 type Tcppkt_t struct {
 	Ether  Etherhdr_t
 	Iphdr  Ip4hdr_t
@@ -473,7 +474,7 @@ type Tcppkt_t struct {
 // writes pseudo header partial cksum to the TCP header cksum field. the sum is
 // not complemented so that the partial pseudo header cksum can be summed with
 // the rest of the TCP cksum (offloaded to the NIC).
-// / Crc computes the pseudo header checksum.
+// /       Crc computes the pseudo header checksum.
 func (tp *Tcppkt_t) Crc(l4len int, sip, dip Ip4_t) {
 	sum := uint32(uint16(sip))
 	sum += uint32(uint16(sip >> 16))
@@ -488,12 +489,12 @@ func (tp *Tcppkt_t) Crc(l4len int, sip, dip Ip4_t) {
 	tp.Tcphdr.Cksum = Htons(uint16(sum))
 }
 
-// / Hdrbytes returns slices for each header in the packet.
+// /       Hdrbytes returns slices for each header in the packet.
 func (tp *Tcppkt_t) Hdrbytes() ([]uint8, []uint8, []uint8) {
 	return tp.Ether.Bytes(), tp.Iphdr.Bytes(), tp.Tcphdr.Bytes()
 }
 
-// / Icmppkt_t represents an ICMP packet with headers.
+// /       Icmppkt_t represents an ICMP packet with headers.
 type Icmppkt_t struct {
 	Ether Etherhdr_t
 	Iphdr Ip4hdr_t
@@ -507,7 +508,7 @@ type Icmppkt_t struct {
 	Data  []uint8
 }
 
-// / Init fills the packet headers for the given addresses and type.
+// /       Init fills the packet headers for the given addresses and type.
 func (ic *Icmppkt_t) Init(smac, dmac *Mac_t, sip, dip Ip4_t, typ uint8,
 	data []uint8) {
 	var z Icmppkt_t
@@ -519,7 +520,7 @@ func (ic *Icmppkt_t) Init(smac, dmac *Mac_t, sip, dip Ip4_t, typ uint8,
 	ic.Data = data
 }
 
-// / Crc computes the ICMP checksum over the packet.
+// /       Crc computes the ICMP checksum over the packet.
 func (ic *Icmppkt_t) Crc() {
 	sum := uint32(ic.Typ) + uint32(ic.Code)<<8
 	sum += uint32(ic.Cksum)
@@ -542,7 +543,7 @@ func (ic *Icmppkt_t) Crc() {
 	ic.Cksum = ret
 }
 
-// / Hdrbytes returns all header bytes of the ICMP packet.
+// /       Hdrbytes returns all header bytes of the ICMP packet.
 func (ic *Icmppkt_t) Hdrbytes() []uint8 {
 	const hdrsz = ETHERLEN + IP4LEN + 2*1 + 3*2
 	return (*[hdrsz]uint8)(unsafe.Pointer(ic))[:]

--- a/biscuit/src/ixgbe/ixgbe.go
+++ b/biscuit/src/ixgbe/ixgbe.go
@@ -107,12 +107,12 @@ func template(n int) ixgbereg_t {
 	return _xreg(0xa600, uint(n), 245, 4)
 }
 
-// / FCRTH returns the flow control receive threshold register for queue n.
+// /       FCRTH returns the flow control receive threshold register for queue n.
 func FCRTH(n int) ixgbereg_t {
 	return _xreg(0x3260, uint(n), 8, 4)
 }
 
-// / RDBAL returns the receive descriptor base address low register for queue n.
+// /       RDBAL returns the receive descriptor base address low register for queue n.
 func RDBAL(n int) ixgbereg_t {
 	if n < 64 {
 		return _xreg(0x1000, uint(n), 64, 0x40)
@@ -121,7 +121,7 @@ func RDBAL(n int) ixgbereg_t {
 	}
 }
 
-// / RDBAH returns the receive descriptor base address high register for queue n.
+// /       RDBAH returns the receive descriptor base address high register for queue n.
 func RDBAH(n int) ixgbereg_t {
 	if n < 64 {
 		return _xreg(0x1004, uint(n), 64, 0x40)
@@ -130,7 +130,7 @@ func RDBAH(n int) ixgbereg_t {
 	}
 }
 
-// / RDLEN returns the receive descriptor length register for queue n.
+// /       RDLEN returns the receive descriptor length register for queue n.
 func RDLEN(n int) ixgbereg_t {
 	if n < 64 {
 		return _xreg(0x1008, uint(n), 64, 0x40)
@@ -139,7 +139,7 @@ func RDLEN(n int) ixgbereg_t {
 	}
 }
 
-// / SRRCTL returns the split receive control register for queue n.
+// /       SRRCTL returns the split receive control register for queue n.
 func SRRCTL(n int) ixgbereg_t {
 	if n < 64 {
 		return _xreg(0x1014, uint(n), 64, 0x40)
@@ -148,7 +148,7 @@ func SRRCTL(n int) ixgbereg_t {
 	}
 }
 
-// / RXDCTL returns the receive descriptor control register for queue n.
+// /       RXDCTL returns the receive descriptor control register for queue n.
 func RXDCTL(n int) ixgbereg_t {
 	if n < 64 {
 		return _xreg(0x1028, uint(n), 64, 0x40)
@@ -157,7 +157,7 @@ func RXDCTL(n int) ixgbereg_t {
 	}
 }
 
-// / RDT returns the receive descriptor tail register for queue n.
+// /       RDT returns the receive descriptor tail register for queue n.
 func RDT(n int) ixgbereg_t {
 	if n < 64 {
 		return _xreg(0x1018, uint(n), 64, 0x40)
@@ -166,7 +166,7 @@ func RDT(n int) ixgbereg_t {
 	}
 }
 
-// / RDH returns the receive descriptor head register for queue n.
+// /       RDH returns the receive descriptor head register for queue n.
 func RDH(n int) ixgbereg_t {
 	if n < 64 {
 		return _xreg(0x1010, uint(n), 64, 0x40)
@@ -175,62 +175,62 @@ func RDH(n int) ixgbereg_t {
 	}
 }
 
-// / QPRC returns the queue packet receive count register for queue n.
+// /       QPRC returns the queue packet receive count register for queue n.
 func QPRC(n int) ixgbereg_t {
 	return _xreg(0x1030, uint(n), 16, 0x40)
 }
 
-// / QPRDC returns the queue packet receive drop count register for queue n.
+// /       QPRDC returns the queue packet receive drop count register for queue n.
 func QPRDC(n int) ixgbereg_t {
 	return _xreg(0x1430, uint(n), 16, 0x40)
 }
 
-// / PFUTA returns the perfect filter table address register for queue n.
+// /       PFUTA returns the perfect filter table address register for queue n.
 func PFUTA(n int) ixgbereg_t {
 	return _xreg(0xf400, uint(n), 128, 4)
 }
 
-// / TDBAL returns the transmit descriptor base address low register.
+// /       TDBAL returns the transmit descriptor base address low register.
 func TDBAL(n int) ixgbereg_t {
 	return _xreg(0x6000, uint(n), 128, 0x40)
 }
 
-// / TDBAH returns the transmit descriptor base address high register.
+// /       TDBAH returns the transmit descriptor base address high register.
 func TDBAH(n int) ixgbereg_t {
 	return _xreg(0x6004, uint(n), 128, 0x40)
 }
 
-// / TDLEN returns the transmit descriptor length register.
+// /       TDLEN returns the transmit descriptor length register.
 func TDLEN(n int) ixgbereg_t {
 	return _xreg(0x6008, uint(n), 128, 0x40)
 }
 
-// / TDH returns the transmit descriptor head register.
+// /       TDH returns the transmit descriptor head register.
 func TDH(n int) ixgbereg_t {
 	return _xreg(0x6010, uint(n), 128, 0x40)
 }
 
-// / TDT returns the transmit descriptor tail register.
+// /       TDT returns the transmit descriptor tail register.
 func TDT(n int) ixgbereg_t {
 	return _xreg(0x6018, uint(n), 128, 0x40)
 }
 
-// / TXDCTL returns the transmit descriptor control register.
+// /       TXDCTL returns the transmit descriptor control register.
 func TXDCTL(n int) ixgbereg_t {
 	return _xreg(0x6028, uint(n), 128, 0x40)
 }
 
-// / TDWBAL returns the transmit descriptor write-back address low register.
+// /       TDWBAL returns the transmit descriptor write-back address low register.
 func TDWBAL(n int) ixgbereg_t {
 	return _xreg(0x6038, uint(n), 128, 0x40)
 }
 
-// / TDWBAH returns the transmit descriptor write-back address high register.
+// /       TDWBAH returns the transmit descriptor write-back address high register.
 func TDWBAH(n int) ixgbereg_t {
 	return _xreg(0x603c, uint(n), 128, 0x40)
 }
 
-// / RSCCTL returns the receive side coalescing control register.
+// /       RSCCTL returns the receive side coalescing control register.
 func RSCCTL(n int) ixgbereg_t {
 	if n < 64 {
 		return _xreg(0x102c, uint(n), 64, 0x40)
@@ -239,7 +239,7 @@ func RSCCTL(n int) ixgbereg_t {
 	}
 }
 
-// / DCA_RXCTRL returns the DCA receive control register.
+// /       DCA_RXCTRL returns the DCA receive control register.
 func DCA_RXCTRL(n int) ixgbereg_t {
 	if n < 64 {
 		return _xreg(0x100c, uint(n), 64, 0x40)
@@ -248,47 +248,47 @@ func DCA_RXCTRL(n int) ixgbereg_t {
 	}
 }
 
-// / RTRPT4C returns the receive target rate register.
+// /       RTRPT4C returns the receive target rate register.
 func RTRPT4C(n int) ixgbereg_t {
 	return _xreg(0x2140, uint(n), 8, 4)
 }
 
-// / RTTPT2C returns the transmit packet timer register.
+// /       RTTPT2C returns the transmit packet timer register.
 func RTTPT2C(n int) ixgbereg_t {
 	return _xreg(0xdc20, uint(n), 8, 4)
 }
 
-// / RTTDT2C returns the transmit descriptor timer register.
+// /       RTTDT2C returns the transmit descriptor timer register.
 func RTTDT2C(n int) ixgbereg_t {
 	return _xreg(0x4910, uint(n), 8, 4)
 }
 
-// / RXPBSIZE returns the receive packet buffer size register.
+// /       RXPBSIZE returns the receive packet buffer size register.
 func RXPBSIZE(n int) ixgbereg_t {
 	return _xreg(0x3c00, uint(n), 8, 4)
 }
 
-// / TXPBSIZE returns the transmit packet buffer size register.
+// /       TXPBSIZE returns the transmit packet buffer size register.
 func TXPBSIZE(n int) ixgbereg_t {
 	return _xreg(0xcc00, uint(n), 8, 4)
 }
 
-// / TXPBTHRESH returns the transmit packet buffer threshold register.
+// /       TXPBTHRESH returns the transmit packet buffer threshold register.
 func TXPBTHRESH(n int) ixgbereg_t {
 	return _xreg(0x4950, uint(n), 8, 4)
 }
 
-// / TQSM returns the transmit queue statistic mapping register.
+// /       TQSM returns the transmit queue statistic mapping register.
 func TQSM(n int) ixgbereg_t {
 	return _xreg(0x8600, uint(n), 32, 4)
 }
 
-// / IVAR returns the interrupt vector allocation register.
+// /       IVAR returns the interrupt vector allocation register.
 func IVAR(n int) ixgbereg_t {
 	return _xreg(0x900, uint(n), 64, 4)
 }
 
-// / EITR returns the interrupt throttling register for vector n.
+// /       EITR returns the interrupt throttling register for vector n.
 func EITR(n int) ixgbereg_t {
 	if n < 24 {
 		return _xreg(0x820, uint(n), 128, 4)
@@ -297,42 +297,42 @@ func EITR(n int) ixgbereg_t {
 	}
 }
 
-// / PFVLVFB returns the PF VLAN filter table buffer register.
+// /       PFVLVFB returns the PF VLAN filter table buffer register.
 func PFVLVFB(n int) ixgbereg_t {
 	return _xreg(0xf200, uint(n), 128, 4)
 }
 
-// / VFTA returns the VLAN filter table array register.
+// /       VFTA returns the VLAN filter table array register.
 func VFTA(n int) ixgbereg_t {
 	return _xreg(0xa000, uint(n), 128, 4)
 }
 
-// / PFVFSPOOF returns the spoofed packet register for VF n.
+// /       PFVFSPOOF returns the spoofed packet register for VF n.
 func PFVFSPOOF(n int) ixgbereg_t {
 	return _xreg(0x8200, uint(n), 8, 4)
 }
 
-// / MPSAR returns the MAC pool select array register.
+// /       MPSAR returns the MAC pool select array register.
 func MPSAR(n int) ixgbereg_t {
 	return _xreg(0xa600, uint(n), 256, 4)
 }
 
-// / QPTC_L returns the lower 32 bits of the per-queue packet transmit counter.
+// /       QPTC_L returns the lower 32 bits of the per-queue packet transmit counter.
 func QPTC_L(n int) ixgbereg_t {
 	return _xreg(0x8700, uint(n), 16, 8)
 }
 
-// / QPTC returns the per-queue packet transmit counter.
+// /       QPTC returns the per-queue packet transmit counter.
 func QPTC(n int) ixgbereg_t {
 	return _xreg(0x8680, uint(n), 16, 4)
 }
 
-// / RAH returns the receive address high register.
+// /       RAH returns the receive address high register.
 func RAH(n uint) ixgbereg_t {
 	return _xreg(0xa204, uint(n), 128, 8)
 }
 
-// / RAL returns the receive address low register.
+// /       RAL returns the receive address low register.
 func RAL(n uint) ixgbereg_t {
 	return _xreg(0xa200, uint(n), 128, 8)
 }
@@ -940,24 +940,29 @@ func (x *ixgbe_t) pg_new() (*mem.Pg_t, mem.Pa_t) {
 	return a, b
 }
 
+// /      Lmac returns the link MAC address of the device.
 func (x *ixgbe_t) Lmac() *Mac_t {
 	return &x.mac
 }
 
+// /      Tx_raw queues a raw Ethernet frame for transmission.
 // returns after buf is enqueued to be trasmitted. buf's contents are copied to
 // the DMA buffer, so buf's memory can be reused/freed
 func (x *ixgbe_t) Tx_raw(buf [][]uint8) bool {
 	return x._tx_nowait(buf, false, false, false, 0, 0)
 }
 
+// /      Tx_ipv4 queues a preformatted IPv4 packet for transmission.
 func (x *ixgbe_t) Tx_ipv4(buf [][]uint8) bool {
 	return x._tx_nowait(buf, true, false, false, 0, 0)
 }
 
+// /      Tx_tcp queues a preformatted TCP segment for transmission.
 func (x *ixgbe_t) Tx_tcp(buf [][]uint8) bool {
 	return x._tx_nowait(buf, true, true, false, 0, 0)
 }
 
+// /      Tx_tcp_tso sends a TCP segment using TSO with the specified MSS.
 func (x *ixgbe_t) Tx_tcp_tso(buf [][]uint8, tcphlen, mss int) bool {
 	return x._tx_nowait(buf, true, true, true, tcphlen, mss)
 }
@@ -1933,7 +1938,7 @@ func (x *ixgbe_t) _dbc_init() {
 	x.rs(RTRPCS, v)
 }
 
-// / Ixgbe_init registers the driver with the PCI subsystem.
+// /       Ixgbe_init registers the driver with the PCI subsystem.
 func Ixgbe_init() {
 	pci.Pci_register_intel(pci.PCI_DEV_X540T, attach_ixgbe)
 }

--- a/biscuit/src/kernel/main.go
+++ b/biscuit/src/kernel/main.go
@@ -1670,13 +1670,13 @@ var thefs *fs.Fs_t
 
 const diskfs = false
 
-// / main initializes device drivers, CPUs, and the filesystem
-// / before scheduling the initial process.
-// / Major steps:
-// /   1. Set up physical memory and output system details.
-// /   2. Attach hardware devices and configure interrupts.
-// /   3. Start secondary CPUs, mount the filesystem, and launch init.
-// / Global state: populates global device handles and CPU information.
+// /       main initializes device drivers, CPUs, and the filesystem
+// /       before scheduling the initial process.
+// /       Major steps:
+// /         1. Set up physical memory and output system details.
+// /         2. Attach hardware devices and configure interrupts.
+// /         3. Start secondary CPUs, mount the filesystem, and launch init.
+// /       Global state: populates global device handles and CPU information.
 func main() {
 	res.Kernel = true
 	//runtime.GCDebug(1)


### PR DESCRIPTION
## Summary
- document exported APIs across fs, hashtable, inet and ixgbe packages
- normalize comment markers to `///`

## Testing
- `go test ./...` *(fails: package references not in standard library)*

------
https://chatgpt.com/codex/tasks/task_e_6849daac6ac88331a6ab2112f2452b80

## Summary by Sourcery

Document and standardize inline documentation for exported APIs across multiple packages.

Enhancements:
- Normalize comment markers to ‘///’ for consistency across codebase
- Add ‘///’ documentation comments for exported types and functions in fs, hashtable, inet, and ixgbe packages