### PR TITLE
Add documentation comments

### DIFF
--- a/biscuit/src/kernel/syscall.go
+++ b/biscuit/src/kernel/syscall.go
@@ -99,6 +99,7 @@ type syscall_t struct {
 
 var sys = &syscall_t{}
 
+/// Syscall handles all process system calls.
 func (s *syscall_t) Syscall(p *proc.Proc_t, tid defs.Tid_t, tf *[defs.TFSIZE]uintptr) int {
 
 	if p.Doomed() {
@@ -269,7 +270,7 @@ var console = &console_t{}
 
 func (c *console_t) Cons_poll(pm fdops.Pollmsg_t) (fdops.Ready_t, defs.Err_t) {
 	cons.pollc <- pm
-	return <- cons.pollret, 0
+	return <-cons.pollret, 0
 }
 
 func (c *console_t) Cons_read(ub fdops.Userio_i, offset int) (int, defs.Err_t) {
@@ -413,6 +414,7 @@ func sys_pause(p *proc.Proc_t) int {
 	return -1
 }
 
+/// Sys_close closes the given file descriptor.
 func (s *syscall_t) Sys_close(p *proc.Proc_t, fdn int) int {
 	fd, ok := p.Fd_del(fdn)
 	if !ok {
@@ -3470,6 +3472,7 @@ func insertargs(p *proc.Proc_t, sargs []ustr.Ustr) (int, int, defs.Err_t) {
 	return len(args), argstart, 0
 }
 
+/// Sys_exit terminates the process with the given status.
 func (s *syscall_t) Sys_exit(p *proc.Proc_t, tid defs.Tid_t, status int) {
 	// set doomed so all other threads die
 	p.Doomall()

--- a/biscuit/src/limits/limits.go
+++ b/biscuit/src/limits/limits.go
@@ -3,12 +3,13 @@ package limits
 import "unsafe"
 import "sync/atomic"
 
+/// Lhits counts limit hits.
 var Lhits int
 
-// / Sysatomic_t is a numeric limit that can be atomically updated.
+/// Sysatomic_t is a numeric limit that can be atomically updated.
 type Sysatomic_t int64
 
-// / Syslimit_t tracks system wide resource limits.
+/// Syslimit_t tracks system wide resource limits.
 type Syslimit_t struct {
 	// protected by proclock
 	Sysprocs int
@@ -36,10 +37,10 @@ type Syslimit_t struct {
 	Blocks int
 }
 
-// / Syslimit describes the configured system wide limits.
+/// Syslimit describes the configured system wide limits.
 var Syslimit *Syslimit_t = MkSysLimit()
 
-// / MkSysLimit returns a pointer to the default set of limits.
+/// MkSysLimit returns a pointer to the default set of limits.
 func MkSysLimit() *Syslimit_t {
 	return &Syslimit_t{
 		Sysprocs: 1e4,
@@ -59,7 +60,7 @@ func (s *Sysatomic_t) _aptr() *int64 {
 	return (*int64)(unsafe.Pointer(s))
 }
 
-// / Given increases the limit by the provided amount.
+/// Given increases the limit by the provided amount.
 func (s *Sysatomic_t) Given(_n uint) {
 	n := int64(_n)
 	if n < 0 {
@@ -68,8 +69,8 @@ func (s *Sysatomic_t) Given(_n uint) {
 	atomic.AddInt64(s._aptr(), n)
 }
 
-// / Taken tries to decrement the limit by the provided amount.
-// / It returns true on success.
+/// Taken tries to decrement the limit by the provided amount.
+/// It returns true on success.
 func (s *Sysatomic_t) Taken(_n uint) bool {
 	n := int64(_n)
 	if n < 0 {
@@ -83,12 +84,12 @@ func (s *Sysatomic_t) Taken(_n uint) bool {
 	return false
 }
 
-// / Take decrements the limit and reports whether it succeeded.
+/// Take decrements the limit and reports whether it succeeded.
 func (s *Sysatomic_t) Take() bool {
 	return s.Taken(1)
 }
 
-// / Give increments the limit by one.
+/// Give increments the limit by one.
 func (s *Sysatomic_t) Give() {
 	s.Given(1)
 }

--- a/biscuit/src/mem/dmap.go
+++ b/biscuit/src/mem/dmap.go
@@ -7,35 +7,35 @@ import "fmt"
 
 // lowest userspace address
 
-// / VREC is the recursive mapping slot used by the kernel.
+/// VREC is the recursive mapping slot used by the kernel.
 const VREC int = 0x42
 
-// / VDIRECT is the direct-map slot.
+/// VDIRECT is the direct-map slot.
 const VDIRECT int = 0x44
 
-// / VEND marks the end of kernel virtual space.
+/// VEND marks the end of kernel virtual space.
 const VEND int = 0x50
 
-// / VUSER is the first user-space slot.
+/// VUSER is the first user-space slot.
 const VUSER int = 0x59
 
-// / USERMIN is the lowest user virtual address.
+/// USERMIN is the lowest user virtual address.
 const USERMIN int = VUSER << 39
 
-// / DMAPLEN is the length of the direct map in bytes.
+/// DMAPLEN is the length of the direct map in bytes.
 const DMAPLEN int = 1 << 39
 
-// / Vdirect holds the virtual address of the direct map region.
+/// Vdirect holds the virtual address of the direct map region.
 var Vdirect = uintptr(VDIRECT << 39)
 
-// / Dmaplen returns a slice over the direct map starting at p for l bytes.
+/// Dmaplen returns a slice over the direct map starting at p for l bytes.
 func Dmaplen(p Pa_t, l int) []uint8 {
 	_dmap := (*[DMAPLEN]uint8)(unsafe.Pointer(Vdirect))
 	return _dmap[p : p+Pa_t(l)]
 }
 
-// / Dmaplen32 is like Dmaplen but operates on 32-bit units.
-// / p and l must be multiples of 4.
+/// Dmaplen32 is like Dmaplen but operates on 32-bit units.
+/// p and l must be multiples of 4.
 func Dmaplen32(p uintptr, l int) []uint32 {
 	if p%4 != 0 || l%4 != 0 {
 		panic("not 32bit aligned")
@@ -83,22 +83,22 @@ func caddr(l4 int, ppd int, pd int, pt int, off int) *int {
 	return (*int)(unsafe.Pointer(uintptr(ret)))
 }
 
-// / Kent_t records a kernel page-map entry.
+/// Kent_t records a kernel page-map entry.
 type Kent_t struct {
 	Pml4slot int
 	Entry    Pa_t
 }
 
-// / Zerobpg is a byte representation of the zero page.
+/// Zerobpg is a byte representation of the zero page.
 var Zerobpg *Bytepg_t
 
-// / P_zeropg is the physical address of Zerobpg.
+/// P_zeropg is the physical address of Zerobpg.
 var P_zeropg Pa_t
 
-// / Kents contains all kernel PML4 entries.
+/// Kents contains all kernel PML4 entries.
 var Kents = make([]Kent_t, 0, 5)
 
-// / Dmap_init installs the direct map covering all physical memory.
+/// Dmap_init installs the direct map covering all physical memory.
 func Dmap_init() {
 	//kpmpages.pminit()
 
@@ -187,10 +187,10 @@ func Dmap_init() {
 	Zerobpg = Pg2bytes(Zeropg)
 }
 
-// / Kpmapp caches the kernel's top-level page map.
+/// Kpmapp caches the kernel's top-level page map.
 var Kpmapp *Pmap_t
 
-// / Kpmap returns the kernel's pmap pointer.
+/// Kpmap returns the kernel's pmap pointer.
 func Kpmap() *Pmap_t {
 	if Kpmapp == nil {
 		dur := caddr(VREC, VREC, VREC, VREC, 0)

--- a/biscuit/src/msi/msi.go
+++ b/biscuit/src/msi/msi.go
@@ -2,10 +2,10 @@ package msi
 
 import "sync"
 
-// / Msivec_t represents an MSI interrupt vector.
+/// Msivec_t represents an MSI interrupt vector.
 type Msivec_t uint
 
-// / Msivecs_t tracks available MSI vectors.
+/// Msivecs_t tracks available MSI vectors.
 type Msivecs_t struct {
 	sync.Mutex
 	avail map[Msivec_t]bool
@@ -16,7 +16,7 @@ var msivecs = Msivecs_t{
 		61: true, 62: true, 63: true},
 }
 
-// / Msi_alloc allocates an available MSI vector.
+/// Msi_alloc allocates an available MSI vector.
 func Msi_alloc() Msivec_t {
 	msivecs.Lock()
 	defer msivecs.Unlock()
@@ -28,7 +28,7 @@ func Msi_alloc() Msivec_t {
 	panic("no more MSI vecs")
 }
 
-// / Msi_free releases a previously allocated MSI vector.
+/// Msi_free releases a previously allocated MSI vector.
 func Msi_free(vector Msivec_t) {
 	msivecs.Lock()
 	defer msivecs.Unlock()

--- a/biscuit/src/oommsg/oommsg.go
+++ b/biscuit/src/oommsg/oommsg.go
@@ -1,9 +1,9 @@
 package oommsg
 
-// / OomCh is notified when the system runs out of memory.
+/// OomCh is notified when the system runs out of memory.
 var OomCh chan Oommsg_t = make(chan Oommsg_t)
 
-// / Oommsg_t is sent on OomCh when memory is exhausted.
+/// Oommsg_t is sent on OomCh when memory is exhausted.
 type Oommsg_t struct {
 	Need   int
 	Resume chan bool


### PR DESCRIPTION
## Summary
- document exported symbols with `///` comments in kernel, limits, mem, msi, and oom packages
- keep Go formatting clean

## Testing
- `go vet ./...` *(fails: package lookups and internal packages not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_6849daad41008331a757a5bf910fbd55