### PR TITLE
Add Doxygen comments to timer utilities

### DIFF
--- a/src/time/sleep.go
+++ b/src/time/sleep.go
@@ -4,8 +4,9 @@
 
 package time
 
-// Sleep pauses the current goroutine for at least the duration d.
-// A negative or zero duration causes Sleep to return immediately.
+// / Sleep pauses the current goroutine for at least the provided duration.
+// / \param d Minimum time to sleep.
+// / A negative or zero duration causes Sleep to return immediately.
 func Sleep(d Duration)
 
 // runtimeNano returns the current value of the runtime clock in nanoseconds.
@@ -42,37 +43,35 @@ func when(d Duration) int64 {
 func startTimer(*runtimeTimer)
 func stopTimer(*runtimeTimer) bool
 
-// The Timer type represents a single event.
-// When the Timer expires, the current time will be sent on C,
-// unless the Timer was created by AfterFunc.
-// A Timer must be created with NewTimer or AfterFunc.
+// / Timer represents a single event that fires in the future.
+// / When the Timer expires, the current time will be sent on C
+// / unless the Timer was created by AfterFunc. A Timer must be
+// / created with NewTimer or AfterFunc.
 type Timer struct {
 	C <-chan Time
 	r runtimeTimer
 }
 
-// Stop prevents the Timer from firing.
-// It returns true if the call stops the timer, false if the timer has already
-// expired or been stopped.
-// Stop does not close the channel, to prevent a read from the channel succeeding
-// incorrectly.
-//
-// To prevent a timer created with NewTimer from firing after a call to Stop,
-// check the return value and drain the channel.
-// For example, assuming the program has not received from t.C already:
-//
-// 	if !t.Stop() {
-// 		<-t.C
-// 	}
-//
-// This cannot be done concurrent to other receives from the Timer's
-// channel.
-//
-// For a timer created with AfterFunc(d, f), if t.Stop returns false, then the timer
-// has already expired and the function f has been started in its own goroutine;
-// Stop does not wait for f to complete before returning.
-// If the caller needs to know whether f is completed, it must coordinate
-// with f explicitly.
+/**
+ * Stop prevents the Timer from firing.
+ * \return true if the call stops the timer, false if the timer has already
+ * expired or been stopped. Stop does not close the channel to avoid
+ * incorrectly succeeding reads.
+ *
+ * To prevent a timer created with NewTimer from firing after a call to Stop,
+ * check the return value and drain the channel. Example:
+ * \code
+ * if !t.Stop() {
+ *     <-t.C
+ * }
+ * \endcode
+ * This cannot be done concurrently with other receives from the Timer's channel.
+ *
+ * For a timer created with AfterFunc(d, f), if Stop returns false then the
+ * timer has already expired and the function has been started in its own
+ * goroutine; Stop does not wait for f to complete. If the caller needs to know
+ * whether f is completed, it must coordinate with f explicitly.
+ */
 func (t *Timer) Stop() bool {
 	if t.r.f == nil {
 		panic("time: Stop called on uninitialized Timer")
@@ -80,8 +79,10 @@ func (t *Timer) Stop() bool {
 	return stopTimer(&t.r)
 }
 
-// NewTimer creates a new Timer that will send
-// the current time on its channel after at least duration d.
+// / NewTimer creates a new Timer that will send the current time on its
+// / channel after at least duration d.
+// / \param d Time delay before the timer fires.
+// / \return Pointer to the newly created Timer.
 func NewTimer(d Duration) *Timer {
 	c := make(chan Time, 1)
 	t := &Timer{
@@ -96,30 +97,29 @@ func NewTimer(d Duration) *Timer {
 	return t
 }
 
-// Reset changes the timer to expire after duration d.
-// It returns true if the timer had been active, false if the timer had
-// expired or been stopped.
-//
-// Resetting a timer must take care not to race with the send into t.C
-// that happens when the current timer expires.
-// If a program has already received a value from t.C, the timer is known
-// to have expired, and t.Reset can be used directly.
-// If a program has not yet received a value from t.C, however,
-// the timer must be stopped and—if Stop reports that the timer expired
-// before being stopped—the channel explicitly drained:
-//
-// 	if !t.Stop() {
-// 		<-t.C
-// 	}
-// 	t.Reset(d)
-//
-// This should not be done concurrent to other receives from the Timer's
-// channel.
-//
-// Note that it is not possible to use Reset's return value correctly, as there
-// is a race condition between draining the channel and the new timer expiring.
-// Reset should always be invoked on stopped or expired channels, as described above.
-// The return value exists to preserve compatibility with existing programs.
+/**
+ * Reset changes the timer to expire after duration d.
+ * \param d New duration for the timer.
+ * \return true if the timer had been active, false if it had expired or been stopped.
+ *
+ * Resetting a timer must take care not to race with the send into t.C that
+ * happens when the current timer expires. If a program has already received
+ * from t.C, the timer is known to have expired and Reset can be used directly.
+ * Otherwise the timer must be stopped and, if Stop reports that the timer
+ * expired before being stopped, the channel must be drained:
+ * \code
+ * if !t.Stop() {
+ *     <-t.C
+ * }
+ * t.Reset(d)
+ * \endcode
+ * This should not be done concurrently with other receives from the Timer's channel.
+ *
+ * Note that it is not possible to use Reset's return value correctly because
+ * there is a race condition between draining the channel and the new timer
+ * expiring. Reset should always be invoked on stopped or expired timers as described above.
+ * The return value exists to preserve compatibility with existing programs.
+ */
 func (t *Timer) Reset(d Duration) bool {
 	if t.r.f == nil {
 		panic("time: Reset called on uninitialized Timer")
@@ -143,19 +143,24 @@ func sendTime(c interface{}, seq uintptr) {
 	}
 }
 
-// After waits for the duration to elapse and then sends the current time
-// on the returned channel.
-// It is equivalent to NewTimer(d).C.
-// The underlying Timer is not recovered by the garbage collector
-// until the timer fires. If efficiency is a concern, use NewTimer
-// instead and call Timer.Stop if the timer is no longer needed.
+/**
+ * After waits for the duration to elapse and then sends the current time on
+ * the returned channel. It is equivalent to NewTimer(d).C. The underlying
+ * Timer is not recovered by the garbage collector until the timer fires. If
+ * efficiency is a concern, use NewTimer instead and call Timer.Stop if the timer
+ * is no longer needed.
+ */
 func After(d Duration) <-chan Time {
 	return NewTimer(d).C
 }
 
-// AfterFunc waits for the duration to elapse and then calls f
-// in its own goroutine. It returns a Timer that can
-// be used to cancel the call using its Stop method.
+/**
+ * AfterFunc waits for the duration to elapse and then calls f in its own
+ * goroutine.
+ * \param d Duration to wait before calling f.
+ * \param f Function to invoke.
+ * \return Timer that can be used to cancel the call using its Stop method.
+ */
 func AfterFunc(d Duration, f func()) *Timer {
 	t := &Timer{
 		r: runtimeTimer{


### PR DESCRIPTION
## Summary
- document exported APIs in `src/time/sleep.go`
- convert comments to Doxygen style

## Testing
- `go test ./...` *(fails: package resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a984b6b60833185717cfea84c40dc

## Summary by Sourcery

Documentation:
- Convert comments for Sleep, Timer, Stop, NewTimer, Reset, After, and AfterFunc to Doxygen format with \param, \return, and code examples